### PR TITLE
LevelSelectLayer::init, GauntletLayer::init and CreatorLayer functions

### DIFF
--- a/bindings/2.200/GeometryDash-extras.bro
+++ b/bindings/2.200/GeometryDash-extras.bro
@@ -8721,14 +8721,6 @@ class TimerTriggerGameObject : EffectGameObject {
 }
 
 [[link(android)]]
-class BoomScrollLayerDelegate {
-	TodoReturn scrollLayerMoved(cocos2d::CCPoint);
-	TodoReturn scrollLayerScrolledToPage(BoomScrollLayer*, int);
-	TodoReturn scrollLayerScrollingStarted(BoomScrollLayer*);
-	TodoReturn scrollLayerWillScrollToPage(BoomScrollLayer*, int);
-}
-
-[[link(android)]]
 class CameraTriggerGameObject : EffectGameObject {
 	TodoReturn getSaveString(GJBaseGameLayer*);
 	TodoReturn triggerObject(GJBaseGameLayer*, int, gd::vector<int> const*);

--- a/bindings/2.200/GeometryDash-extras.bro
+++ b/bindings/2.200/GeometryDash-extras.bro
@@ -1185,41 +1185,6 @@ class ColorAction2 {
 }
 
 [[link(android)]]
-class CreatorLayer : cocos2d::CCLayer, cocos2d::CCSceneTransitionDelegate, DialogDelegate {
-	void onMapPacks(cocos2d::CCObject* sender);
-	void onMyLevels(cocos2d::CCObject* sender);
-	void onTopLists(cocos2d::CCObject* sender);
-	void onChallenge(cocos2d::CCObject* sender);
-	void onGauntlets(cocos2d::CCObject* sender);
-	TodoReturn dialogClosed(DialogLayer*);
-	void onDailyLevel(cocos2d::CCObject* sender);
-	void onEventLevel(cocos2d::CCObject* sender);
-	void onFameLevels(cocos2d::CCObject* sender);
-	void onMultiplayer(cocos2d::CCObject* sender);
-	void onSavedLevels(cocos2d::CCObject* sender);
-	void onSecretVault(cocos2d::CCObject* sender);
-	void onWeeklyLevel(cocos2d::CCObject* sender);
-	virtual void keyBackClicked();
-	void onAdventureMap(cocos2d::CCObject* sender);
-	void onLeaderboards(cocos2d::CCObject* sender);
-	void onOnlineLevels(cocos2d::CCObject* sender);
-	void onTreasureRoom(cocos2d::CCObject* sender);
-	virtual void sceneWillResume();
-	void onFeaturedLevels(cocos2d::CCObject* sender);
-	TodoReturn checkQuestsStatus();
-	void onOnlyFullVersion(cocos2d::CCObject* sender);
-	TodoReturn canPlayOnlineLevels();
-	virtual bool init();
-	TodoReturn scene();
-	static CreatorLayer* create();
-	void onBack(cocos2d::CCObject* sender);
-	void onPaths(cocos2d::CCObject* sender);
-	~CreatorLayer();
-}
-
-
-
-[[link(android)]]
 class FindBPMLayer : CreateGuidelinesLayer {
 	TodoReturn calculateBPM();
 	TodoReturn registerTouch();
@@ -1986,21 +1951,6 @@ class FileOperation {
 	TodoReturn getFilePath();
 	TodoReturn readFile();
 	TodoReturn saveFile();
-}
-
-[[link(android)]]
-class GauntletLayer : cocos2d::CCLayer, LevelManagerDelegate {
-	TodoReturn setupGauntlet(cocos2d::CCArray*);
-	virtual void keyBackClicked();
-	TodoReturn loadLevelsFailed(char const*, int);
-	TodoReturn unlockActiveItem();
-	TodoReturn loadLevelsFinished(cocos2d::CCArray*, char const*, int);
-	bool init(GauntletType);
-	TodoReturn scene(GauntletType);
-	static GauntletLayer* create(GauntletType);
-	void onBack(cocos2d::CCObject* sender);
-	void onLevel(cocos2d::CCObject* sender);
-	~GauntletLayer();
 }
 
 [[link(android)]]
@@ -5507,27 +5457,6 @@ class LevelSearchLayer : cocos2d::CCLayer, TextInputDelegate, FLAlertLayerProtoc
 	TodoReturn checkTime(int);
 	void onFriends(cocos2d::CCObject* sender);
 	~LevelSearchLayer();
-}
-
-[[link(android)]]
-class LevelSelectLayer : cocos2d::CCLayer, BoomScrollLayerDelegate, DynamicScrollDelegate {
-	void onDownload(cocos2d::CCObject* sender);
-	TodoReturn colorForPage(int);
-	TodoReturn getColorValue(int, int, float);
-	virtual void keyBackClicked();
-	TodoReturn scrollLayerMoved(cocos2d::CCPoint);
-	TodoReturn updatePageWithObject(cocos2d::CCObject*, cocos2d::CCObject*);
-	bool init(int);
-	TodoReturn scene(int);
-	static LevelSelectLayer* create(int);
-	void onBack(cocos2d::CCObject* sender);
-	void onInfo(cocos2d::CCObject* sender);
-	void onNext(cocos2d::CCObject* sender);
-	void onPlay(cocos2d::CCObject* sender);
-	void onPrev(cocos2d::CCObject* sender);
-	virtual void keyDown(cocos2d::enumKeyCodes);
-	TodoReturn tryShowAd();
-	~LevelSelectLayer();
 }
 
 [[link(android)]]

--- a/bindings/2.200/GeometryDash-extras.bro
+++ b/bindings/2.200/GeometryDash-extras.bro
@@ -7719,15 +7719,6 @@ class LevelCommentDelegate {
 }
 
 [[link(android)]]
-class LevelManagerDelegate {
-	virtual void setupPageInfo(gd::string, char const*) {}
-	virtual void loadLevelsFailed(char const*) {}
-	virtual void loadLevelsFailed(char const*, int) {}
-	virtual void loadLevelsFinished(cocos2d::CCArray*, char const*) {}
-	virtual void loadLevelsFinished(cocos2d::CCArray*, char const*, int) {}
-}
-
-[[link(android)]]
 class MusicBrowserDelegate {
 	TodoReturn musicBrowserClosed(MusicBrowser*);
 }

--- a/bindings/2.200/GeometryDash-extras.bro
+++ b/bindings/2.200/GeometryDash-extras.bro
@@ -1184,41 +1184,6 @@ class ColorAction2 {
 	// ColorAction2(cocos2d::_ccColor3B, cocos2d::_ccColor3B, float, double, bool, int, float, float);
 }
 
-[[link(android)]]
-class CreatorLayer : cocos2d::CCLayer, cocos2d::CCSceneTransitionDelegate, DialogDelegate {
-	void onMapPacks(cocos2d::CCObject* sender);
-	void onMyLevels(cocos2d::CCObject* sender) = win 0x6FE90;
-	void onTopLists(cocos2d::CCObject* sender);
-	void onChallenge(cocos2d::CCObject* sender);
-	void onGauntlets(cocos2d::CCObject* sender);
-	TodoReturn dialogClosed(DialogLayer*);
-	void onDailyLevel(cocos2d::CCObject* sender);
-	void onEventLevel(cocos2d::CCObject* sender);
-	void onFameLevels(cocos2d::CCObject* sender);
-	void onMultiplayer(cocos2d::CCObject* sender);
-	void onSavedLevels(cocos2d::CCObject* sender);
-	void onSecretVault(cocos2d::CCObject* sender);
-	void onWeeklyLevel(cocos2d::CCObject* sender);
-	virtual void keyBackClicked();
-	void onAdventureMap(cocos2d::CCObject* sender);
-	void onLeaderboards(cocos2d::CCObject* sender);
-	void onOnlineLevels(cocos2d::CCObject* sender);
-	void onTreasureRoom(cocos2d::CCObject* sender);
-	virtual void sceneWillResume();
-	void onFeaturedLevels(cocos2d::CCObject* sender);
-	TodoReturn checkQuestsStatus();
-	void onOnlyFullVersion(cocos2d::CCObject* sender);
-	TodoReturn canPlayOnlineLevels();
-	virtual bool init();
-	TodoReturn scene();
-	static CreatorLayer* create();
-	void onBack(cocos2d::CCObject* sender);
-	void onPaths(cocos2d::CCObject* sender);
-	~CreatorLayer();
-}
-
-
-
 [[link(android)]
 class FindBPMLayer : CreateGuidelinesLayer {
 	TodoReturn calculateBPM();
@@ -1986,22 +1951,6 @@ class FileOperation {
 	TodoReturn getFilePath();
 	TodoReturn readFile();
 	TodoReturn saveFile();
-}
-
-[[link(android)]]
-=======
-class GauntletLayer : cocos2d::CCLayer, LevelManagerDelegate {
-	TodoReturn setupGauntlet(cocos2d::CCArray*);
-	virtual void keyBackClicked();
-	virtual void loadLevelsFailed(char const*, int);
-	TodoReturn unlockActiveItem();
-	virtual void loadLevelsFinished(cocos2d::CCArray*, char const*, int);
-	bool init(GauntletType);
-	TodoReturn scene(GauntletType);
-	static GauntletLayer* create(GauntletType);
-	void onBack(cocos2d::CCObject* sender);
-	void onLevel(cocos2d::CCObject* sender);
-	~GauntletLayer();
 }
 
 [[link(android)]]

--- a/bindings/2.200/GeometryDash-extras.bro
+++ b/bindings/2.200/GeometryDash-extras.bro
@@ -1184,7 +1184,7 @@ class ColorAction2 {
 	// ColorAction2(cocos2d::_ccColor3B, cocos2d::_ccColor3B, float, double, bool, int, float, float);
 }
 
-[[link(android)]
+[[link(android)]]
 class FindBPMLayer : CreateGuidelinesLayer {
 	TodoReturn calculateBPM();
 	TodoReturn registerTouch();

--- a/bindings/2.200/GeometryDash.bro
+++ b/bindings/2.200/GeometryDash.bro
@@ -152,6 +152,75 @@ class ScrollingLayer : cocos2d::CCLayerColor {
 }
 
 [[link(android)]]
+class CreatorLayer : cocos2d::CCLayer, cocos2d::CCSceneTransitionDelegate, DialogDelegate {
+	void onMapPacks(cocos2d::CCObject* sender) = win 0x70250;
+	void onMyLevels(cocos2d::CCObject* sender) = win 0x6FE90;
+	void onTopLists(cocos2d::CCObject* sender) = win 0x70160;
+	void onChallenge(cocos2d::CCObject* sender) = win 0x70910;
+	void onGauntlets(cocos2d::CCObject* sender);
+	TodoReturn dialogClosed(DialogLayer*);
+	void onDailyLevel(cocos2d::CCObject* sender);
+	void onEventLevel(cocos2d::CCObject* sender) = win 0x70740;
+	void onFameLevels(cocos2d::CCObject* sender);
+	void onMultiplayer(cocos2d::CCObject* sender) = win 0x70330;
+	void onSavedLevels(cocos2d::CCObject* sender) = win 0x6FF80;
+	void onSecretVault(cocos2d::CCObject* sender);
+	void onWeeklyLevel(cocos2d::CCObject* sender);
+	virtual void keyBackClicked();
+	void onAdventureMap(cocos2d::CCObject* sender) = win 0x706C0;
+	void onLeaderboards(cocos2d::CCObject* sender);
+	void onOnlineLevels(cocos2d::CCObject* sender) = win 0x701E0;
+	void onTreasureRoom(cocos2d::CCObject* sender) = win 0x70C50;
+	virtual void sceneWillResume();
+	void onFeaturedLevels(cocos2d::CCObject* sender) = win 0x700C0;
+	TodoReturn checkQuestsStatus();
+	void onOnlyFullVersion(cocos2d::CCObject* sender);
+	TodoReturn canPlayOnlineLevels();
+	virtual bool init();
+	TodoReturn scene();
+	static CreatorLayer* create();
+	void onBack(cocos2d::CCObject* sender);
+	void onPaths(cocos2d::CCObject* sender);
+	~CreatorLayer();
+}
+
+[[link(android)]]
+class LevelSelectLayer : cocos2d::CCLayer, BoomScrollLayerDelegate, DynamicScrollDelegate {
+	void onDownload(cocos2d::CCObject* sender);
+	TodoReturn colorForPage(int);
+	TodoReturn getColorValue(int, int, float);
+	virtual void keyBackClicked();
+	TodoReturn scrollLayerMoved(cocos2d::CCPoint);
+	TodoReturn updatePageWithObject(cocos2d::CCObject*, cocos2d::CCObject*);
+	bool init(int)  = win 0x2632F0;
+	TodoReturn scene(int);
+	static LevelSelectLayer* create(int);
+	void onBack(cocos2d::CCObject* sender);
+	void onInfo(cocos2d::CCObject* sender);
+	void onNext(cocos2d::CCObject* sender);
+	void onPlay(cocos2d::CCObject* sender);
+	void onPrev(cocos2d::CCObject* sender);
+	virtual void keyDown(cocos2d::enumKeyCodes);
+	TodoReturn tryShowAd();
+	~LevelSelectLayer();
+}
+
+[[link(android)]]
+class GauntletLayer : cocos2d::CCLayer, LevelManagerDelegate {
+	TodoReturn setupGauntlet(cocos2d::CCArray*);
+	virtual void keyBackClicked();
+	TodoReturn loadLevelsFailed(char const*, int);
+	TodoReturn unlockActiveItem();
+	TodoReturn loadLevelsFinished(cocos2d::CCArray*, char const*, int);
+	bool init(GauntletType) = win 0x183860;
+	TodoReturn scene(GauntletType);
+	static GauntletLayer* create(GauntletType);
+	void onBack(cocos2d::CCObject* sender);
+	void onLevel(cocos2d::CCObject* sender);
+	~GauntletLayer();
+}
+
+[[link(android)]]
 class CCMenuItemSpriteExtra : cocos2d::CCMenuItemSprite {
 	void useAnimationType(MenuAnimationType type) {
         m_startPosition = this->getNormalImage()->getPosition();

--- a/bindings/2.200/GeometryDash.bro
+++ b/bindings/2.200/GeometryDash.bro
@@ -185,6 +185,14 @@ class CreatorLayer : cocos2d::CCLayer, cocos2d::CCSceneTransitionDelegate, Dialo
 }
 
 [[link(android)]]
+class BoomScrollLayerDelegate {
+	TodoReturn scrollLayerMoved(cocos2d::CCPoint);
+	TodoReturn scrollLayerScrolledToPage(BoomScrollLayer*, int);
+	TodoReturn scrollLayerScrollingStarted(BoomScrollLayer*);
+	TodoReturn scrollLayerWillScrollToPage(BoomScrollLayer*, int);
+}
+
+[[link(android)]]
 class LevelSelectLayer : cocos2d::CCLayer, BoomScrollLayerDelegate, DynamicScrollDelegate {
 	void onDownload(cocos2d::CCObject* sender);
 	TodoReturn colorForPage(int);

--- a/bindings/2.200/GeometryDash.bro
+++ b/bindings/2.200/GeometryDash.bro
@@ -214,6 +214,15 @@ class LevelSelectLayer : cocos2d::CCLayer, BoomScrollLayerDelegate, DynamicScrol
 }
 
 [[link(android)]]
+class LevelManagerDelegate {
+	virtual void setupPageInfo(gd::string, char const*) {}
+	virtual void loadLevelsFailed(char const*) {}
+	virtual void loadLevelsFailed(char const*, int) {}
+	virtual void loadLevelsFinished(cocos2d::CCArray*, char const*) {}
+	virtual void loadLevelsFinished(cocos2d::CCArray*, char const*, int) {}
+}
+
+[[link(android)]]
 class GauntletLayer : cocos2d::CCLayer, LevelManagerDelegate {
 	TodoReturn setupGauntlet(cocos2d::CCArray*);
 	virtual void keyBackClicked();


### PR DESCRIPTION
`CreatorLayer::onMapPacks`
`CreatorLayer::onMyLevels`
`CreatorLayer::onTopLists`
`CreatorLayer::onChallenge`
`CreatorLayer::onEventLevel`
`CreatorLayer::onMultiplayer`
`CreatorLayer::onSavedLevels`
`CreatorLayer::onAdventureMap`
`CreatorLayer::onOnlineLevels`
`CreatorLayer::onTreasureRoom`

Removed CreatorLayer, LevelSelectLayer and GauntletLayer from GeometryDash-extras.bro and added to GeometryDash.bro