### PR TITLE
add static return type for GameLevelManager::getBasePostString

### DIFF
--- a/bindings/2.204/GeometryDash.bro
+++ b/bindings/2.204/GeometryDash.bro
@@ -3939,7 +3939,7 @@ class GameLevelManager : cocos2d::CCNode {
 	TodoReturn getActiveSmartTemplate();
 	TodoReturn getAllSmartTemplates();
 	TodoReturn getAllUsedSongIDs();
-	TodoReturn getBasePostString() = win 0xfb5b0;
+	static gd::string getBasePostString() = win 0xfb5b0;
 	bool getBoolForKey(char const*) = win 0x111d40;
 	const char* getCommentKey(int ID, int page, int mode, CommentKeyType keytype) = win 0x1091d0;
 	cocos2d::CCArray* getCompletedLevels(bool) = win 0xf7790;

--- a/bindings/2.205/GeometryDash.bro
+++ b/bindings/2.205/GeometryDash.bro
@@ -3901,7 +3901,7 @@ class GameLevelManager : cocos2d::CCNode {
 	TodoReturn getActiveSmartTemplate();
 	TodoReturn getAllSmartTemplates();
 	TodoReturn getAllUsedSongIDs();
-	static gd::strig getBasePostString();
+	static gd::string getBasePostString();
 	bool getBoolForKey(char const*);
 	TodoReturn getCommentKey(int, int, int, CommentKeyType);
 	TodoReturn getCompletedDailyLevels();

--- a/bindings/2.205/GeometryDash.bro
+++ b/bindings/2.205/GeometryDash.bro
@@ -3901,7 +3901,7 @@ class GameLevelManager : cocos2d::CCNode {
 	TodoReturn getActiveSmartTemplate();
 	TodoReturn getAllSmartTemplates();
 	TodoReturn getAllUsedSongIDs();
-	TodoReturn getBasePostString();
+	static gd::strig getBasePostString();
 	bool getBoolForKey(char const*);
 	TodoReturn getCommentKey(int, int, int, CommentKeyType);
 	TodoReturn getCompletedDailyLevels();


### PR DESCRIPTION
Sorry about the previous pull request. I managed to figure out why my fork was getting so messy and I managed to clean it up...
On top of that I added a return type for `getBasePostString()` which I recently reverse engineered.
I'm still using Wyliemaster's field names for some things he's reverse engineered still but this will change in the future...

```c++
std::string static GameLevelManager::getBasePostString()
{
    auto GM = GameManager::sharedState();

    std::string BasePostString;
    BasePostString += cocos2d::CCString::createWithFormat(
            "gameVersion=%i&binaryVersion=%i&udid=%s&uuid=%i", 22, 0x28, GM->m_sPlayerUDID, GM->m_nChkRand - GM->m_nChkSeed
            )->getCString();
    auto AM = GJAccountManager::sharedState();
    /* This is what it is not sure why it's this way with accountIDs, but it is... - Calloc  */
    BasePostString += cocos2d::CCString::createWithFormat(
        "&accountID=%i&gjp2=%s",AM->m_nPlayerAccountID - AM->m_nPlayerAccountIDRand, AM->m_sGJP2
    )->getCString();
    return BasePostString;
}
```
I do think it's weird that this was actually a static function but at the same time no class fields from the`GameLevelManager` are being called in this function which makes sense...
 I still haven't figured out the actual fieldname of `PlayerAccountIDRand` for v2.205/v2.204 yet but this is a start in the right direction.
 