### PR TITLE
Updates to GameLevelManager and CCTextInputNode

### DIFF
--- a/bindings/2.204/GeometryDash.bro
+++ b/bindings/2.204/GeometryDash.bro
@@ -3969,7 +3969,7 @@ class GameLevelManager : cocos2d::CCNode {
 	const char *getLenKey(int len);
 	TodoReturn getLenVal(int);
 	void getLevelComments(int ID, int page, int total, int mode, CommentKeyType keytype) = win 0x108160;
-	inline const char* getLevelDownloadKey(int levelID, bool isGauntlet){
+	const char* getLevelDownloadKey(int levelID, bool isGauntlet){
 	    return cocos2d::CCString::createWithFormat("%i_%i", levelID, isGauntlet)->getCString();
 	};
 	const char* getLevelKey(int levelID);
@@ -4016,7 +4016,7 @@ class GameLevelManager : cocos2d::CCNode {
 	TodoReturn getStoredUserMessageReply(int);
 	TodoReturn getTimeLeft(char const*, float) = win 0xf8fc0;
 	void getTopArtists(int page, int total) = win 0x105d80;
-	inline const char* getTopArtistsKey(int page){
+	const char* getTopArtistsKey(int page){
 	    return cocos2d::CCString::createWithFormat("topArtists_%i", page)->getCString();
 	};
 	TodoReturn getUploadMessageKey(int);

--- a/bindings/2.204/GeometryDash.bro
+++ b/bindings/2.204/GeometryDash.bro
@@ -3969,7 +3969,7 @@ class GameLevelManager : cocos2d::CCNode {
 	const char *getLenKey(int len);
 	TodoReturn getLenVal(int);
 	void getLevelComments(int ID, int page, int total, int mode, CommentKeyType keytype) = win 0x108160;
-	const char* getLevelDownloadKey(int levelID, bool isGauntlet){
+	inline const char* getLevelDownloadKey(int levelID, bool isGauntlet){
 	    return cocos2d::CCString::createWithFormat("%i_%i", levelID, isGauntlet)->getCString();
 	};
 	const char* getLevelKey(int levelID);
@@ -4016,7 +4016,7 @@ class GameLevelManager : cocos2d::CCNode {
 	TodoReturn getStoredUserMessageReply(int);
 	TodoReturn getTimeLeft(char const*, float) = win 0xf8fc0;
 	void getTopArtists(int page, int total) = win 0x105d80;
-	const char* getTopArtistsKey(int page){
+	inline const char* getTopArtistsKey(int page){
 	    return cocos2d::CCString::createWithFormat("topArtists_%i", page)->getCString();
 	};
 	TodoReturn getUploadMessageKey(int);

--- a/bindings/2.204/GeometryDash.bro
+++ b/bindings/2.204/GeometryDash.bro
@@ -1253,7 +1253,7 @@ class CCTextInputNode : cocos2d::CCLayer, cocos2d::CCIMEDelegate, cocos2d::CCTex
 	virtual TodoReturn onClickTrackNode(bool) = win 0x2f600;
 	virtual void keyboardWillShow(cocos2d::CCIMEKeyboardNotificationInfo&) = win 0x2f4d0;
 	virtual void keyboardWillHide(cocos2d::CCIMEKeyboardNotificationInfo&) = win 0x2f5a0;
-	virtual bool onTextFieldInsertText(cocos2d::CCTextFieldTTF*, char const*, int, cocos2d::enumKeyCodes) = win 0x2f6b0;
+	virtual bool onTextFieldInsertText(cocos2d::CCTextFieldTTF* pSender, char const* text, int nLen, cocos2d::enumKeyCodes keyCodes) = win 0x2f6b0;
 	virtual bool onTextFieldAttachWithIME(cocos2d::CCTextFieldTTF*) = win 0x2fa30;
 	virtual bool onTextFieldDetachWithIME(cocos2d::CCTextFieldTTF*) = win 0x2fd50;
 

--- a/bindings/2.204/GeometryDash.bro
+++ b/bindings/2.204/GeometryDash.bro
@@ -3969,7 +3969,9 @@ class GameLevelManager : cocos2d::CCNode {
 	const char *getLenKey(int len);
 	TodoReturn getLenVal(int);
 	void getLevelComments(int ID, int page, int total, int mode, CommentKeyType keytype) = win 0x108160;
-	TodoReturn getLevelDownloadKey(int, bool);
+	const char* getLevelDownloadKey(int levelID, bool isGauntlet){
+	    return cocos2d::CCString::createWithFormat("%i_%i", levelID, isGauntlet)->getCString();
+	};
 	const char* getLevelKey(int levelID);
 	void getLevelLeaderboard(GJGameLevel*, LevelLeaderboardType, LevelLeaderboardMode) = win 0x1053a0;
 	TodoReturn getLevelLeaderboardKey(int, LevelLeaderboardType, LevelLeaderboardMode);
@@ -4014,7 +4016,9 @@ class GameLevelManager : cocos2d::CCNode {
 	TodoReturn getStoredUserMessageReply(int);
 	TodoReturn getTimeLeft(char const*, float) = win 0xf8fc0;
 	void getTopArtists(int page, int total) = win 0x105d80;
-	TodoReturn getTopArtistsKey(int);
+	const char* getTopArtistsKey(int page){
+	    return cocos2d::CCString::createWithFormat("topArtists_%i", page)->getCString();
+	};
 	TodoReturn getUploadMessageKey(int);
 	TodoReturn getUserInfoKey(int);
 	TodoReturn getUserList(UserListType) = win 0x10d2a0;

--- a/bindings/2.204/GeometryDash.bro
+++ b/bindings/2.204/GeometryDash.bro
@@ -4018,7 +4018,7 @@ class GameLevelManager : cocos2d::CCNode {
 	void getTopArtists(int page, int total) = win 0x105d80;
 	const char* getTopArtistsKey(int page){
 	    return cocos2d::CCString::createWithFormat("topArtists_%i", page)->getCString();
-	};
+	}
 	TodoReturn getUploadMessageKey(int);
 	TodoReturn getUserInfoKey(int);
 	TodoReturn getUserList(UserListType) = win 0x10d2a0;

--- a/bindings/2.204/GeometryDash.bro
+++ b/bindings/2.204/GeometryDash.bro
@@ -3971,7 +3971,7 @@ class GameLevelManager : cocos2d::CCNode {
 	void getLevelComments(int ID, int page, int total, int mode, CommentKeyType keytype) = win 0x108160;
 	const char* getLevelDownloadKey(int levelID, bool isGauntlet){
 	    return cocos2d::CCString::createWithFormat("%i_%i", levelID, isGauntlet)->getCString();
-	};
+	}
 	const char* getLevelKey(int levelID);
 	void getLevelLeaderboard(GJGameLevel*, LevelLeaderboardType, LevelLeaderboardMode) = win 0x1053a0;
 	TodoReturn getLevelLeaderboardKey(int, LevelLeaderboardType, LevelLeaderboardMode);

--- a/bindings/2.205/GeometryDash.bro
+++ b/bindings/2.205/GeometryDash.bro
@@ -3859,8 +3859,8 @@ class GameLevelManager : cocos2d::CCNode {
 	}
 
 	TodoReturn acceptFriendRequest(int, int);
-	TodoReturn accountIDForUserID(int);
-	TodoReturn addDLToActive(char const*);
+	int accountIDForUserID(int accountID);
+	void addDLToActive(char const* tag);
 	TodoReturn areGauntletsLoaded();
 	TodoReturn banUser(int);
 	TodoReturn blockUser(int);
@@ -3981,8 +3981,8 @@ class GameLevelManager : cocos2d::CCNode {
 	TodoReturn getStoredUserMessage(int);
 	TodoReturn getStoredUserMessageReply(int);
 	TodoReturn getTimeLeft(char const*, float);
-	TodoReturn getTopArtists(int, int);
-	TodoReturn getTopArtistsKey(int);
+	void getTopArtists(int page, int total);
+	const char *getTopArtistsKey(int page);
 	TodoReturn getUploadMessageKey(int);
 	TodoReturn getUserInfoKey(int);
 	TodoReturn getUserList(UserListType);
@@ -4053,7 +4053,7 @@ class GameLevelManager : cocos2d::CCNode {
 	TodoReturn onGetUserMessagesCompleted(gd::string, gd::string);
 	TodoReturn onGetUsersCompleted(gd::string, gd::string);
 	TodoReturn onLikeItemCompleted(gd::string, gd::string);
-	TodoReturn onProcessHttpRequestCompleted(cocos2d::extension::CCHttpClient*, cocos2d::extension::CCHttpResponse*);
+	TodoReturn onProcessHttpRequestCompleted(cocos2d::extension::CCHttpClient* client, cocos2d::extension::CCHttpResponse* response);
 	TodoReturn onRateDemonCompleted(gd::string, gd::string);
 	TodoReturn onRateStarsCompleted(gd::string, gd::string);
 	TodoReturn onReadFriendRequestCompleted(gd::string, gd::string);
@@ -4084,7 +4084,7 @@ class GameLevelManager : cocos2d::CCNode {
 	TodoReturn rateStars(int, int);
 	TodoReturn readFriendRequest(int);
 	TodoReturn removeDelimiterChars(gd::string, bool);
-	TodoReturn removeDLFromActive(char const*);
+	void removeDLFromActive(char const* tag);
 	TodoReturn removeFriend(int);
 	TodoReturn removeLevelDownloadedKeysFromDict(cocos2d::CCDictionary*);
 	TodoReturn removeUserFromList(int, UserListType);


### PR DESCRIPTION
I have no clue if `getLevelDownloadKey` and `getTopArtistkey` functions are inline on windows or not but they appear to be non-existant when decompiling `windows v2.204` on ghidra. I will leave that editing up to you guys on weather or not `getTopArtistsKey` and  `getLevelDownloadKey`  should be considered inline functions or not even though I think they are. I have a screenshot of where `getLevelDownloadKey` should've been in the `downloadLevel` function.

![image](https://github.com/geode-sdk/bindings/assets/140273795/a0792333-f24c-41d8-a523-9196cfe32dcb)

However, feel free to make any changes if you think I screwed up somewhere, I left the `inline` keyword out unless someone else thinks otherwise.
