### PR TITLE
Change CCTextInputNode class member m_unknown3 to m_filterSwearWords

### DIFF
--- a/bindings/2.204/GeometryDash.bro
+++ b/bindings/2.204/GeometryDash.bro
@@ -1218,12 +1218,12 @@ class CCTextInputNode : cocos2d::CCLayer, cocos2d::CCIMEDelegate, cocos2d::CCTex
 		m_placeholderColor = color;
 		this->refreshLabel();
 	}
-    void setAllowedChars(gd::string filter) {
-        m_allowedChars = filter;
-    }
-    cocos2d::CCLabelBMFont* getPlaceholderLabel() {
-        return m_placeholderLabel;
-    }
+	void setAllowedChars(gd::string filter) {
+        	m_allowedChars = filter;
+    	}
+    	cocos2d::CCLabelBMFont* getPlaceholderLabel() {
+        	return m_placeholderLabel;
+    	}
 
 	void addTextArea(TextArea*) = win 0x2e6d0;
 	TodoReturn forceOffset();
@@ -1233,9 +1233,9 @@ class CCTextInputNode : cocos2d::CCLayer, cocos2d::CCIMEDelegate, cocos2d::CCTex
 	bool init(float, float, char const*, char const*, int, char const*) = win 0x2e500;
 	TodoReturn refreshLabel() = win 0x2ede0;
 	void setLabelNormalColor(cocos2d::ccColor3B color) {
-        m_textColor = color;
-        this->refreshLabel();
-    }
+        	m_textColor = color;
+        	this->refreshLabel();
+    	}
 	void setString(gd::string) = win 0x2e9a0;
 	TodoReturn updateBlinkLabel();
 	TodoReturn updateBlinkLabelToChar(int);

--- a/bindings/2.204/GeometryDash.bro
+++ b/bindings/2.204/GeometryDash.bro
@@ -1180,7 +1180,7 @@ class CCTextInputNode : cocos2d::CCLayer, cocos2d::CCIMEDelegate, cocos2d::CCTex
 		m_delegate = nullptr;
 		m_maxLabelLength = 0;
 		m_placeholderLabel = nullptr;
-		m_unknown3 = false;
+		m_filterSwearWords = false;
 		m_usePasswordChar = false;
 		m_forceOffset = false;
 		m_textArea = nullptr;
@@ -1254,8 +1254,8 @@ class CCTextInputNode : cocos2d::CCLayer, cocos2d::CCIMEDelegate, cocos2d::CCTex
 	virtual void keyboardWillShow(cocos2d::CCIMEKeyboardNotificationInfo&) = win 0x2f4d0;
 	virtual void keyboardWillHide(cocos2d::CCIMEKeyboardNotificationInfo&) = win 0x2f5a0;
 	virtual bool onTextFieldInsertText(cocos2d::CCTextFieldTTF* pSender, char const* text, int nLen, cocos2d::enumKeyCodes keyCodes) = win 0x2f6b0;
-	virtual bool onTextFieldAttachWithIME(cocos2d::CCTextFieldTTF*) = win 0x2fa30;
-	virtual bool onTextFieldDetachWithIME(cocos2d::CCTextFieldTTF*) = win 0x2fd50;
+	virtual bool onTextFieldAttachWithIME(cocos2d::CCTextFieldTTF* tField) = win 0x2fa30;
+	virtual bool onTextFieldDetachWithIME(cocos2d::CCTextFieldTTF* tField) = win 0x2fd50;
 
 	bool m_numberInput;
 	gd::string m_caption;
@@ -1276,7 +1276,7 @@ class CCTextInputNode : cocos2d::CCLayer, cocos2d::CCIMEDelegate, cocos2d::CCTex
 	TextInputDelegate* m_delegate;
 	int m_maxLabelLength;
 	cocos2d::CCLabelBMFont* m_placeholderLabel;
-	bool m_unknown3;
+	bool m_filterSwearWords;
 	bool m_usePasswordChar;
 	bool m_forceOffset;
 	TextArea* m_textArea;

--- a/bindings/2.205/GeometryDash.bro
+++ b/bindings/2.205/GeometryDash.bro
@@ -1216,8 +1216,8 @@ class CCTextInputNode : cocos2d::CCLayer, cocos2d::CCIMEDelegate, cocos2d::CCTex
         return m_placeholderLabel;
     }
 
-	TodoReturn addTextArea(TextArea*);
-	TodoReturn forceOffset();
+	void addTextArea(TextArea* tArea);
+	void forceOffset();
 	gd::string getString() {
 		return m_textField->getString();
 	}
@@ -1229,7 +1229,7 @@ class CCTextInputNode : cocos2d::CCLayer, cocos2d::CCIMEDelegate, cocos2d::CCTex
 	TodoReturn updateBlinkLabelToChar(int);
 	TodoReturn updateCursorPosition(cocos2d::CCPoint, cocos2d::CCRect) = ios 0x17532c;
 	TodoReturn updateDefaultFontValues(gd::string);
-	TodoReturn updateLabel(gd::string);
+	void updateLabel(gd::string label);
 
 	virtual void visit();
 	virtual bool ccTouchBegan(cocos2d::CCTouch*, cocos2d::CCEvent*) = ios 0x175770;
@@ -1242,8 +1242,8 @@ class CCTextInputNode : cocos2d::CCLayer, cocos2d::CCIMEDelegate, cocos2d::CCTex
 	virtual void keyboardWillShow(cocos2d::CCIMEKeyboardNotificationInfo&);
 	virtual void keyboardWillHide(cocos2d::CCIMEKeyboardNotificationInfo&);
 	virtual bool onTextFieldInsertText(cocos2d::CCTextFieldTTF*, char const*, int, cocos2d::enumKeyCodes);
-	virtual bool onTextFieldAttachWithIME(cocos2d::CCTextFieldTTF*);
-	virtual bool onTextFieldDetachWithIME(cocos2d::CCTextFieldTTF*);
+	virtual bool onTextFieldAttachWithIME(cocos2d::CCTextFieldTTF* pSender);
+	virtual bool onTextFieldDetachWithIME(cocos2d::CCTextFieldTTF* pSender);
 
 	bool m_numberInput;
 	gd::string m_caption;
@@ -1264,7 +1264,7 @@ class CCTextInputNode : cocos2d::CCLayer, cocos2d::CCIMEDelegate, cocos2d::CCTex
 	TextInputDelegate* m_delegate;
 	int m_maxLabelLength;
 	cocos2d::CCLabelBMFont* m_placeholderLabel;
-	bool m_unknown3;
+	bool m_filterSwearWords;
 	bool m_usePasswordChar;
 	bool m_forceOffset;
 	TextArea* m_textArea;

--- a/bindings/2.205/GeometryDash.bro
+++ b/bindings/2.205/GeometryDash.bro
@@ -1171,7 +1171,7 @@ class CCTextInputNode : cocos2d::CCLayer, cocos2d::CCIMEDelegate, cocos2d::CCTex
 		m_delegate = nullptr;
 		m_maxLabelLength = 0;
 		m_placeholderLabel = nullptr;
-		m_unknown3 = false;
+		m_filterSwearWords = false;
 		m_usePasswordChar = false;
 		m_forceOffset = false;
 		m_textArea = nullptr;


### PR DESCRIPTION
I have little more information about it including what m_unknown3 is referring to. I will update in my [2.2 decompiled repo](https://github.com/CallocGD/GD-2.2-Decompiled/blob/main/GD/code/src/CCTextInputNode.cpp) soon but `m_unknown3` is `m_filterSwearWords`. I will also try to merge some of your guy's inline void functions to my repository as well (if you don't mind) . I'm trying to learn about this object more since it's one of the most creative class objects robtop has created hence my deep research about it. Anyways I hope this is useful to all of you.


