### PR TITLE
Bindings for GJBaseGameLayer object sections

### DIFF
--- a/bindings/2.204/GeometryDash.bro
+++ b/bindings/2.204/GeometryDash.bro
@@ -6233,13 +6233,13 @@ class GJBaseGameLayer : cocos2d::CCLayer, TriggerEffectDelegate {
 	cocos2d::CCLayer* m_objectLayer;
 	PAD = win 0x70, android32 0x70, android64 0xec;
 	std::array<float, 2000> m_massiveFloatArray;
-	PAD = win 0x48, android32 0x4C, android64 0x124;
-	int m_leftSectionIndex; // 29b4
-	int m_rightSectionIndex; // 29b8
-	int m_bottomSectionIndex; // 29bc
-	int m_topSectionIndex; // 29c0
-	PAD = win 0xB8, android32 0xB8, android64 0xB8;
-	bool m_isPracticeMode;
+	PAD = win 0x48, android32 0x54, android64 0x98; // not sure about the android paddings
+	int m_leftSectionIndex; // 29b4 win, 29d4 android32, 30b4 android64
+	int m_rightSectionIndex;
+	int m_bottomSectionIndex;
+	int m_topSectionIndex;
+	PAD = win 0xB8, android32 0xB0, android64 0x144;
+	bool m_isPracticeMode; // 2a7c win, 2a94 android32, 3208 android64
 	bool m_practiceMusicSync;
 	float m_unk2a80;
 	cocos2d::CCNode* m_unk2a84;

--- a/bindings/2.204/GeometryDash.bro
+++ b/bindings/2.204/GeometryDash.bro
@@ -6263,7 +6263,7 @@ class GJBaseGameLayer : cocos2d::CCLayer, TriggerEffectDelegate {
 	gd::vector<gd::vector<gd::vector<GameObject*>*>*> m_sections; // 2c48 win
 	PAD = win 0x48;
 	gd::vector<gd::vector<int>*> m_nonEffectObjectsPerSection; // 2c9c win
-	PAD = win 0xCD;
+	PAD = win 0xC5;
 	cocos2d::CCDrawNode* m_debugDrawNode;
 	PAD = win 0x4;
 	bool m_isDebugDrawEnabled;

--- a/bindings/2.204/GeometryDash.bro
+++ b/bindings/2.204/GeometryDash.bro
@@ -6233,7 +6233,12 @@ class GJBaseGameLayer : cocos2d::CCLayer, TriggerEffectDelegate {
 	cocos2d::CCLayer* m_objectLayer;
 	PAD = win 0x70, android32 0x70, android64 0xec;
 	std::array<float, 2000> m_massiveFloatArray;
-	PAD = win 0x110, android32 0x114, android64 0x1ec;
+	PAD = win 0x48, android32 0x4C, android64 0x124;
+	int m_leftSectionIndex; // 29b4
+	int m_rightSectionIndex; // 29b8
+	int m_bottomSectionIndex; // 29bc
+	int m_topSectionIndex; // 29c0
+	PAD = win 0xB8, android32 0xB8, android64 0xB8;
 	bool m_isPracticeMode;
 	bool m_practiceMusicSync;
 	float m_unk2a80;
@@ -6255,8 +6260,10 @@ class GJBaseGameLayer : cocos2d::CCLayer, TriggerEffectDelegate {
 	PAD = win 0xb0;
 	UILayer* m_uiLayer;
 	PAD = win 0x38;
-	gd::vector<GameObject*> m_sections;
-	PAD = win 0x119;
+	gd::vector<gd::vector<gd::vector<GameObject*>*>*> m_sections; // 2c48 win
+	PAD = win 0x48;
+	gd::vector<gd::vector<int>*> m_nonEffectObjectsPerSection; // 2c9c win
+	PAD = win 0xCD;
 	cocos2d::CCDrawNode* m_debugDrawNode;
 	PAD = win 0x4;
 	bool m_isDebugDrawEnabled;


### PR DESCRIPTION
Bindings for object sections (notably to be able to iterate over objects currently on screen)

GameObjects are divided in sections both horizontally and vertically.
Not sure I understand this completely but each section appears to feature the "gameplay" objects first (those with a hitbox), and the effect objets second (that's what m_nonEffectObjectsPerSection is for).