### PR TITLE
m_objectInfoLabel (Windows and Android)

### DIFF
--- a/bindings/2.204/GeometryDash.bro
+++ b/bindings/2.204/GeometryDash.bro
@@ -2916,7 +2916,7 @@ class EditorUI : cocos2d::CCLayer, FLAlertLayerProtocol, ColorSelectDelegate, GJ
 	cocos2d::CCArray* m_unk1cc;
 	float m_unk1d0;
 	PAD = win 0x30, android32 0x30;
-	cocos2d::CCLabelBMFont* m_unk204;
+	cocos2d::CCLabelBMFont* m_objectInfoLabel;
 	GJRotationControl* m_rotationControl;
 	PAD = win 0xc, android32 0xc;
 	GJScaleControl* m_scaleControl;

--- a/bindings/2.205/GeometryDash.bro
+++ b/bindings/2.205/GeometryDash.bro
@@ -2906,7 +2906,7 @@ class EditorUI : cocos2d::CCLayer, FLAlertLayerProtocol, ColorSelectDelegate, GJ
 
 	PAD = android32 0x3c, android64 0x48;
 
-	CCLabelBMFont* m_objectInfoLabel;
+	cocos2d::CCLabelBMFont* m_objectInfoLabel;
 
 	PAD = android32 0x18, android64 0x28;
 

--- a/bindings/2.205/GeometryDash.bro
+++ b/bindings/2.205/GeometryDash.bro
@@ -2904,7 +2904,11 @@ class EditorUI : cocos2d::CCLayer, FLAlertLayerProtocol, ColorSelectDelegate, GJ
 
 	EditButtonBar* m_buttonBar;
 
-	PAD = android32 0x58, android64 0x78;
+	PAD = android32 0x3c, android64 0x48;
+
+	CCLabelBMFont* m_objectInfoLabel;
+
+	PAD = android32 0x18, android64 0x28;
 
 	GJTransformControl* m_transformControl;
 	PAD = android32 0xc, android64 0x18;


### PR DESCRIPTION
Object info label displayed when selecting an object in the level editor, if enabled, of course.