### PR TITLE
Add return type for LoadingLayer::getLoadingString

### DIFF
--- a/bindings/2.202/GeometryDash.bro
+++ b/bindings/2.202/GeometryDash.bro
@@ -9099,7 +9099,7 @@ class LoadingLayer : cocos2d::CCLayer {
 
 	static LoadingLayer* create(bool);
 
-	TodoReturn getLoadingString() = win 0x275c10;
+	const char* getLoadingString() = win 0x275c10;
 	bool init(bool) = win 0x274d20;
 	TodoReturn loadAssets() = win 0x275580;
 	TodoReturn loadingFinished() = win 0x275490;

--- a/bindings/2.203/GeometryDash.bro
+++ b/bindings/2.203/GeometryDash.bro
@@ -9287,7 +9287,7 @@ class LoadingLayer : cocos2d::CCLayer {
 
 	static LoadingLayer* create(bool);
 
-	TodoReturn getLoadingString() = win 0x2770f0;
+	const char* getLoadingString() = win 0x2770f0;
 	bool init(bool) = win 0x2761e0;
 	TodoReturn loadAssets() = win 0x276a40;
 	TodoReturn loadingFinished() = win 0x276950;

--- a/bindings/2.204/GeometryDash.bro
+++ b/bindings/2.204/GeometryDash.bro
@@ -9883,7 +9883,7 @@ class LoadingLayer : cocos2d::CCLayer {
 
 	static LoadingLayer* create(bool) = win 0x2762d0;
 
-	TodoReturn getLoadingString() = win 0x277280;
+	const char* getLoadingString() = win 0x277280;
 	bool init(bool) = win 0x276370;
 	void loadAssets() = win 0x276bd0;
 	void loadingFinished() = win 0x276ae0;

--- a/bindings/2.205/GeometryDash.bro
+++ b/bindings/2.205/GeometryDash.bro
@@ -9796,7 +9796,7 @@ class LoadingLayer : cocos2d::CCLayer {
 
 	static LoadingLayer* create(bool);
 
-	TodoReturn getLoadingString();
+	const char* getLoadingString();
 	bool init(bool) = ios 0x1d8ce8;
 	void loadAssets() = ios 0x1d949c;
 	void loadingFinished();


### PR DESCRIPTION
I don't think this will have changed across GD versions, so I added it to all the 2.2 versions that didn't have it