### PR TITLE
Add PointNode m_point member and change an unknown member's type to void* inside PlayerObject

### DIFF
--- a/bindings/2.204/GeometryDash.bro
+++ b/bindings/2.204/GeometryDash.bro
@@ -11278,7 +11278,7 @@ class PlayerObject : GameObject, AnimatedSpriteDelegate {
 	cocos2d::CCArray* m_particleSystems;
 	gd::unordered_map<int, GJPointDouble> m_unk594; // insertions are in PlayerObject::rotateGameplayObject
 	gd::unordered_map<int, GameObject*> m_unk5b4;
-	float m_unk5d4;
+	void* m_unk5d4;
 	float m_rotationSpeed;
 	float m_unk5dc;
 	bool m_isRotating;

--- a/bindings/2.204/GeometryDash.bro
+++ b/bindings/2.204/GeometryDash.bro
@@ -11616,6 +11616,9 @@ class PointNode : cocos2d::CCObject {
 	static PointNode* create(cocos2d::CCPoint) = win 0x2274c0;
 
 	bool init(cocos2d::CCPoint);
+  
+  cocos2d::CCPoint m_point;
+
 }
 
 [[link(android)]]

--- a/bindings/2.205/GeometryDash.bro
+++ b/bindings/2.205/GeometryDash.bro
@@ -11171,7 +11171,7 @@ class PlayerObject : GameObject, AnimatedSpriteDelegate {
 	cocos2d::CCArray* m_particleSystems;
 	gd::unordered_map<int, GJPointDouble> m_unk594; // insertions are in PlayerObject::rotateGameplayObject
 	gd::unordered_map<int, GameObject*> m_unk5b4;
-	float m_unk5d4;
+	void* m_unk5d4;
 	float m_rotationSpeed;
 	float m_unk5dc;
 	bool m_isRotating;

--- a/bindings/2.205/GeometryDash.bro
+++ b/bindings/2.205/GeometryDash.bro
@@ -11487,6 +11487,8 @@ class PointNode : cocos2d::CCObject {
 	static PointNode* create(cocos2d::CCPoint);
 
 	bool init(cocos2d::CCPoint);
+
+	cocos2d::CCPoint m_point;
 }
 
 [[link(android)]]

--- a/test/members/Android32.cpp
+++ b/test/members/Android32.cpp
@@ -93,6 +93,7 @@ GEODE_MEMBER_CHECK(PlayLayer, m_nextColorKey, 0x2f38);
 GEODE_MEMBER_CHECK(PlayerObject, m_unk4e4, 0x4d4);
 GEODE_MEMBER_CHECK(PlayerObject, m_collidedObject, 0x514);
 GEODE_MEMBER_CHECK(PlayerObject, m_particleSystems, 0x580);
+GEODE_MEMBER_CHECK(PlayerObject, m_isHidden, 0x5cb);
 GEODE_MEMBER_CHECK(PlayerObject, m_ghostTrail, 0x5d0);
 GEODE_MEMBER_CHECK(PlayerObject, m_waveTrail, 0x610);
 GEODE_MEMBER_CHECK(PlayerObject, m_unk644, 0x62c);

--- a/test/members/Android64.cpp
+++ b/test/members/Android64.cpp
@@ -88,6 +88,7 @@ GEODE_MEMBER_CHECK(PlayerObject, m_platformerXVelocity, 0xac0);
 GEODE_MEMBER_CHECK(PlayerObject, m_isPlatformer, 0xb38);
 GEODE_MEMBER_CHECK(PlayerObject, m_unk950, 0xbe8);
 GEODE_MEMBER_CHECK(PlayerObject, m_unk948, 0xbe0);
+GEODE_MEMBER_CHECK(PlayerObject, m_isHidden, 0x703);
 
 GEODE_MEMBER_CHECK(GameManager, m_playLayer, 0x1d8);
 GEODE_MEMBER_CHECK(GameManager, m_levelEditorLayer, 0x1e0);

--- a/test/members/Windows.cpp
+++ b/test/members/Windows.cpp
@@ -249,5 +249,6 @@ GEODE_MEMBER_CHECK(LevelEditorLayer, m_editorUI, 0x2e24);
 GEODE_MEMBER_CHECK(HardStreak, m_pointArray, 0x158);
 
 GEODE_MEMBER_CHECK(GJPathSprite, m_pathNumber, 0x1fc);
+GEODE_MEMBER_CHECK(PointNode, m_point, 0x34);
 
 #endif


### PR DESCRIPTION
`PointNodes` are what's contained inside a `HardStreak`'s `m_pointArray` array, rather than `CCPoints`. Maybe that should be called `m_pointNodeArray` instead? Let me know if I should add that as an additional commit.

`PlayerObject`'s `m_isHidden` member had the wrong location on Android64, updating a previous unknown type to a pointer fixes that, and probably some other things that are out of alignment as well (`m_rotationSpeed`), according to what dank_meme told me.