### PR TITLE
Rename GameLevelManger m_unkStr1 to m_searchSceneStr and m_unkStr2 to m_searchType9Str;

### DIFF
--- a/bindings/2.204/GeometryDash.bro
+++ b/bindings/2.204/GeometryDash.bro
@@ -4309,8 +4309,8 @@ class GameLevelManager : cocos2d::CCNode {
 	cocos2d::CCDictionary* m_friendRequests;
 	cocos2d::CCDictionary* m_userMessages;
 	cocos2d::CCDictionary* m_userReplies;
-	gd::string m_unkStr1;
-	gd::string m_unkStr2;
+	gd::string m_searchSceneStr;
+	gd::string m_searchType9Str;
 	LeaderboardState m_leaderboardState;
 	bool m_unkEditLevelLayerOnBack;
 	LevelManagerDelegate* m_levelManagerDelegate;

--- a/bindings/2.205/GeometryDash.bro
+++ b/bindings/2.205/GeometryDash.bro
@@ -4262,8 +4262,8 @@ class GameLevelManager : cocos2d::CCNode {
 	cocos2d::CCDictionary* m_friendRequests;
 	cocos2d::CCDictionary* m_userMessages;
 	cocos2d::CCDictionary* m_userReplies;
-	gd::string m_unkStr1;
-	gd::string m_unkStr2;
+	gd::string m_searchSceneStr;
+	gd::string m_searchType9Str;
 	LeaderboardState m_leaderboardState;
 	bool m_unkEditLevelLayerOnBack;
 	LevelManagerDelegate* m_levelManagerDelegate;


### PR DESCRIPTION
It seems like I've figured out this class object since I'm planning on preparing to do a full sweep of a GameLevelManager's decompilation soon hence renaming these felt rather important to me. These weren't too difficult to find but rather required a little bit of thinking here and there.
