### PR TITLE
fix alks silly mistake

### DIFF
--- a/bindings/2.204/GeometryDash.bro
+++ b/bindings/2.204/GeometryDash.bro
@@ -6341,7 +6341,6 @@ class GJBaseGameLayer : cocos2d::CCLayer, TriggerEffectDelegate {
 	PAD = win 0xc4;
 
 	GJGameLoadingLayer* m_loadingLayer; // 2d6c
-	PAD = win 0x4;
 	cocos2d::CCDrawNode* m_debugDrawNode; // 2d74
 	PAD = win 0x4;
 	bool m_isDebugDrawEnabled;

--- a/test/members/Windows.cpp
+++ b/test/members/Windows.cpp
@@ -118,6 +118,7 @@ GEODE_MEMBER_CHECK(PlayLayer, m_attemptLabel, 0x2e4c);
 GEODE_MEMBER_CHECK(PlayLayer, m_progressBar, 0x2e58);
 GEODE_MEMBER_CHECK(PlayLayer, m_colorKeyDict, 0x2f30);
 GEODE_MEMBER_CHECK(PlayLayer, m_nextColorKey, 0x2f58);
+GEODE_MEMBER_CHECK(PlayLayer, m_debugDrawNode, 0x2d70);
 // CustomSongWidget
 
 GEODE_MEMBER_CHECK(CustomSongWidget, m_songInfoObject, 0x110);


### PR DESCRIPTION
before `m_debugDrawNode` was `0x2D70`, but with the changes alk made, it increased the offset to `0x2D74`, which causes crashes when accessing it!