### PR TITLE
Add the other class members for GameObjectCopy

### DIFF
--- a/bindings/2.204/GeometryDash.bro
+++ b/bindings/2.204/GeometryDash.bro
@@ -5331,6 +5331,13 @@ class GameObjectCopy : cocos2d::CCObject {
 	void resetObject();
 
 	GameObject* m_object;
+	cocos2d::CCPoint m_position;
+	float m_rotationX;
+	float m_rotationY;
+	bool m_isFlipX;
+	bool m_isFlipY;
+	float m_customScaleX;
+	float m_customScaleY;
 }
 
 [[link(android)]]

--- a/bindings/2.205/GeometryDash.bro
+++ b/bindings/2.205/GeometryDash.bro
@@ -5286,8 +5286,15 @@ class GameObjectCopy : cocos2d::CCObject {
 
 	bool init(GameObject*);
 	void resetObject();
-
+	
 	GameObject* m_object;
+	cocos2d::CCPoint m_position;
+	float m_rotationX;
+	float m_rotationY;
+	bool m_isFlipX;
+	bool m_isFlipY;
+	float m_customScaleX;
+	float m_customScaleY;
 }
 
 [[link(android)]]


### PR DESCRIPTION
I was trying to find missing GameObject's class by digging through things it's involved with and as I was doing so I ended up filling out all the members for GameObjectCopy.
