### PR TITLE
New Robtop Freebies Found For PlayerObject

### DIFF
--- a/bindings/2.204/GeometryDash.bro
+++ b/bindings/2.204/GeometryDash.bro
@@ -11130,8 +11130,8 @@ class PlayerObject : GameObject, AnimatedSpriteDelegate {
 	void collidedWithObject(float, GameObject*, cocos2d::CCRect, bool) = win 0x2cc3d0;
 	void collidedWithObject(float, GameObject*);
 	void collidedWithObjectInternal(float, GameObject*, cocos2d::CCRect, bool) = win 0x2cc450;
-	void collidedWithSlope(float, GameObject*, bool) = win 0x2ca3c0;
-	void collidedWithSlopeInternal(float, GameObject*, bool) = win 0x2ca420;
+	void collidedWithSlope(float dt, GameObject* object , bool forced) = win 0x2ca3c0;
+	void collidedWithSlopeInternal(float dt, GameObject* object, bool forced) = win 0x2ca420;
 	TodoReturn convertToClosestRotation(float);
 	TodoReturn copyAttributes(PlayerObject*);
 	void createFadeOutDartStreak() = win 0x2d2320;

--- a/bindings/2.205/GeometryDash.bro
+++ b/bindings/2.205/GeometryDash.bro
@@ -11005,8 +11005,8 @@ class PlayerObject : GameObject, AnimatedSpriteDelegate {
 	void collidedWithObject(float, GameObject*, cocos2d::CCRect, bool);
 	void collidedWithObject(float, GameObject*);
 	void collidedWithObjectInternal(float, GameObject*, cocos2d::CCRect, bool);
-	void collidedWithSlope(float, GameObject*, bool);
-	void collidedWithSlopeInternal(float, GameObject*, bool);
+	void collidedWithSlope(float dt, GameObject* object, bool forced);
+	void collidedWithSlopeInternal(float dt, GameObject* object, bool forced);
 	TodoReturn convertToClosestRotation(float);
 	TodoReturn copyAttributes(PlayerObject*);
 	void createFadeOutDartStreak();


### PR DESCRIPTION
I saw a twitch stream from Robtop in a [youtube video](https://youtube.com/watch?v=_wmWuymEZDs) where he originally showcased a bug when developing reversed player actions. In that video, I found the parameter names for `collidedWithSlope` and `collidedWithSlopeInternal` . Now I don't know how useful this information is since the code has changed since his twitch stream but it is likely the parameter names have remained the same since then hence my pull request.
