### PR TITLE
remove HardStreak::stopStroke

### DIFF
--- a/bindings/2.204/GeometryDash.bro
+++ b/bindings/2.204/GeometryDash.bro
@@ -8560,7 +8560,7 @@ class HardStreak : cocos2d::CCDrawNode {
 	}
 	TodoReturn resumeStroke();
 	TodoReturn scheduleAutoUpdate();
-	void stopStroke() = win 0x226890;
+	void stopStroke();
 	callback void updateStroke(float) = win 0x226960;
 
 	virtual bool init() = win 0x226860;


### PR DESCRIPTION
The address doesn't point to a function and I can't be bothered with finding the real address.