### PR TITLE
some bindings nobody will use

### DIFF
--- a/bindings/2.206/GeometryDash.bro
+++ b/bindings/2.206/GeometryDash.bro
@@ -11120,7 +11120,7 @@ class MenuLayer : cocos2d::CCLayer, FLAlertLayerProtocol, GooglePlayDelegate {
 	void onNewgrounds(cocos2d::CCObject* sender) = win 0x3154b0, ios 0x2774b8;
 	void onOptions(cocos2d::CCObject* sender) = win 0x3150d0, ios 0x277420;
 	void onOptionsInstant() = win 0x3150e0, ios 0x276044;
-	void onPlay(cocos2d::CCObject* sender) = win 0x315030, ios 0x2772c8;
+	void onPlay(cocos2d::CCObject* sender) = win 0x315030, ios 0x2772c8, m1 0x31c224, imac 0x394080;
 	void onQuit(cocos2d::CCObject* sender) = win 0x3155f0, m1 0x31c6b4, imac 0x394500;
 	void onRobTop(cocos2d::CCObject* sender) = win 0x314ce0, ios 0x27756c;
 	void onStats(cocos2d::CCObject* sender) = win 0x315270, ios 0x27746c;

--- a/bindings/2.206/GeometryDash.bro
+++ b/bindings/2.206/GeometryDash.bro
@@ -6686,7 +6686,7 @@ class GJBaseGameLayer : cocos2d::CCLayer, TriggerEffectDelegate {
 	TodoReturn reorderObjectSection(GameObject*) = imac 0x11f2d0;
 	TodoReturn reparentObject(cocos2d::CCNode*, cocos2d::CCNode*) = m1 0x63fd70;
 	void resetActiveEnterEffects() = win 0x1ff150, m1 0xef414;
-	TodoReturn resetAreaObjectValues(GameObject*, bool);
+	TodoReturn resetAreaObjectValues(GameObject*, bool) = win 0x2184c0;
 	void resetAudio() = win 0x227690, imac 0x147000, m1 0x11a408;
 	void resetCamera() = win 0x22ec30, imac 0x14e1b0, m1 0x11fd2c;
 	void resetGradientLayers() = win 0x211790;
@@ -10072,7 +10072,7 @@ class LevelEditorLayer : GJBaseGameLayer, LevelSettingsDelegate {
 	TodoReturn pasteGroupState(GameObject*, cocos2d::CCArray*);
 	TodoReturn pasteParticleState(ParticleGameObject*, cocos2d::CCArray*);
 	void processLoadedMoveActions() = imac 0xb7be0, m1 0xa44a4;
-	TodoReturn quickUpdateAllPositions();
+	TodoReturn quickUpdateAllPositions() = win 0x2cbd20;
 	TodoReturn recreateGroups();
 	void redoLastAction() = win inline {
 		return this->handleAction(false, m_redoObjects);

--- a/bindings/2.206/GeometryDash.bro
+++ b/bindings/2.206/GeometryDash.bro
@@ -7979,7 +7979,7 @@ class GJGradientLayer : cocos2d::CCLayerGradient {
 class GJGroundLayer : cocos2d::CCLayer {
 	// virtual ~GJGroundLayer();
 
-	static GJGroundLayer* create(int, int) = win 0x26bfe0, ios 0x32198;
+	static GJGroundLayer* create(int, int) = win 0x26bfe0, ios 0x32198, imac 0x5F4210, m1 0x51C2D0;
 
 	void createLine(int) = win 0x26c890;
 	TodoReturn deactivateGround();


### PR DESCRIPTION
GJBaseGameLayer::resetAreaObjectValues
LevelEditorLayer::quickUpdateAllPositions

ignore the first 3 commits idk