### PR TITLE
CCEGLView fix I think

### DIFF
--- a/codegen/src/ModifyGen.cpp
+++ b/codegen/src/ModifyGen.cpp
@@ -134,6 +134,14 @@ std::string generateModifyHeader(Root const& root, ghc::filesystem::path const& 
             fmt::arg("class_include", class_include)
         );
 
+        #ifndef GEODE_IS_WINDOWS
+        if (can_find(c.name, "CCEGLView")) {
+            single_output += format_strings::modify_end;
+            writeFile(singleFolder / filename, single_output);
+            continue;
+        }
+        #endif
+
         // modify
         for (auto& f : c.fields) {
             auto fn = f.get_as<FunctionBindField>();


### PR DESCRIPTION
IDK at this point (Skips modify macros if class name is `cocos2d::CCEGLView`)

This has been properly tested