### PR TITLE
Attempt to fix iOS members

### DIFF
--- a/bindings/2.206/GeometryDash.bro
+++ b/bindings/2.206/GeometryDash.bro
@@ -14134,13 +14134,13 @@ class PlayLayer : GJBaseGameLayer, CCCircleWaveDelegate, CurrencyRewardDelegate,
 	virtual void circleWaveWillBeRemoved(CCCircleWave*) = win 0x391440, m1 0xa7a3c, imac 0xbba00;
 	virtual void dialogClosed(DialogLayer*) = win 0x3912a0, m1 0xa7a08, imac 0xbb9a0;
 
-	PAD = win 0x30, android32 0x24, android64 0x2c, mac 0x30, ios 0x2c;
+	PAD = win 0x30, android32 0x24, android64 0x2c, mac 0x30, ios 0x30;
 	cocos2d::CCArray* m_coinArray;
-	PAD = win 0x6E, android32 0x3E, android64 0x6E, mac 0x6E;
+	PAD = win 0x6E, android32 0x3E, android64 0x6E, mac 0x6E, ios 0x6e;
 	bool m_isIgnoreDamageEnabled;
 	cocos2d::CCLabelBMFont* m_statusLabel;
 	int m_unk3778;
-	PAD = win 0x18, android32 0x18, android64 0x18, mac 0x18;
+	PAD = win 0x18, android32 0x18, android64 0x18, mac 0x18, ios 0x18;
 	float m_unkSomeFloat;
 	CheckpointObject* m_currentCheckpoint;
 	cocos2d::CCArray* m_checkpointArray;
@@ -14162,7 +14162,7 @@ class PlayLayer : GJBaseGameLayer, CCCircleWaveDelegate, CurrencyRewardDelegate,
 	cocos2d::CCSprite* m_progressBar;
 	cocos2d::CCSprite* m_progressFill;
 	// everything after this comment is probably wrong
-	PAD = win 0x6e, android32 0x40, android64 0x66, mac 0x56;
+	PAD = win 0x6e, android32 0x40, android64 0x66, mac 0x56, ios 0x56;
 	int m_jumps;
 	bool m_hasJumped;
 	int m_uncommittedJumps; // PlayLayer::commitJumps
@@ -14171,9 +14171,9 @@ class PlayLayer : GJBaseGameLayer, CCCircleWaveDelegate, CurrencyRewardDelegate,
 	bool m_inResetDelay;
 	int m_lastAttemptPercent;
 	bool m_endLayerStars; // not verified on android
-	PAD = win 0x3a, android32 0x29, android64 0x3a, mac 0x3a;
+	PAD = win 0x3a, android32 0x29, android64 0x3a, mac 0x3a, ios 0x3a;
 	double m_attemptTime;
-	PAD = win 0x1f, android32 0x27, android64 0x1f, mac 0x1f;
+	PAD = win 0x1f, android32 0x27, android64 0x1f, mac 0x1f, ios 0x1f;
 	bool m_isPaused;
 	bool m_disableGravityEffect;
 	cocos2d::CCLabelBMFont* m_infoLabel;

--- a/bindings/2.206/GeometryDash.bro
+++ b/bindings/2.206/GeometryDash.bro
@@ -7624,7 +7624,7 @@ class GJBaseGameLayer : cocos2d::CCLayer, TriggerEffectDelegate {
 	bool m_decimalPercentage;
 	bool m_extraLDM;
 	bool m_0173;
-	PAD = win 0xc9, android32 0x61, android64 0xC0, mac 0xac;
+	PAD = win 0xc9, android32 0x61, android64 0xC0, mac 0xac, ios 0xac;
 	GJEffectManager* m_effectManager;
 	cocos2d::CCSpriteBatchNode* m_unk950;
 	cocos2d::CCSpriteBatchNode* m_unk958;
@@ -7779,7 +7779,7 @@ class GJBaseGameLayer : cocos2d::CCLayer, TriggerEffectDelegate {
 	gd::unordered_map<int, gd::vector<GameObject*>> m_unknownD48;
 	gd::vector<GameObject*> m_unknownD70;
 	gd::unordered_map<int, gd::vector<GameObject*>> m_unknownD88;
-	PAD = win 0x10, android32 0x28, android64 0x18, mac 0x28;
+	PAD = win 0x10, android32 0x28, android64 0x18, mac 0x28, ios 0x28;
 	cocos2d::CCDictionary* m_groupDict;
 	cocos2d::CCDictionary* m_staticGroupDict;
 	cocos2d::CCDictionary* m_optimizedGroupDict;
@@ -7807,25 +7807,25 @@ class GJBaseGameLayer : cocos2d::CCLayer, TriggerEffectDelegate {
 	cocos2d::CCArray* m_unk1030;
 	cocos2d::CCDictionary* m_unk1038;
 	void* m_unk1040;
-	PAD = win 0x8c, android32 0x50, android64 0x9c, mac 0x64; // (for win) between 0x8 bytes, there is a member thats 0x8 size. I think its a CCDictionary*
+	PAD = win 0x8c, android32 0x50, android64 0x9c, mac 0x64, ios 0x64; // (for win) between 0x8 bytes, there is a member thats 0x8 size. I think its a CCDictionary*
 	std::array<float, 2000> m_massiveFloatArray;
-	PAD = win 0x78, android32 0x4c, android64 0x90, mac 0x68; // not sure about the android paddings
+	PAD = win 0x78, android32 0x4c, android64 0x90, mac 0x68, ios 0x68; // not sure about the android paddings
 	int m_attempts; // found in EndLevelLayer::customSetup
 	bool m_bUnk30b8;
 	int m_leftSectionIndex; // these 4 ints can be found in GJBaseGameLayer::updateDebugDraw or GJBaseGameLayer::updateObjectSection (easier)
 	int m_rightSectionIndex;
 	int m_bottomSectionIndex;
 	int m_topSectionIndex;
-	PAD = win 0x2, android32 0x2, android64 0x2, mac 0x2;
+	PAD = win 0x2, android32 0x2, android64 0x2, mac 0x2, ios 0x2;
 	bool m_isPlatformer;
-	PAD = win 0xc5, android32 0x61, android64 0xb5, mac 0x99;
+	PAD = win 0xc5, android32 0x61, android64 0xb5, mac 0x99, ios 0x99;
 	cocos2d::CCDictionary* m_unk2a50;
 	void* m_unk2a54;
 	ShaderLayer* m_shaderLayer;
 	bool m_bUnk31a0;
 	bool m_bUnk31a1;
 	StartPosObject* m_startPosObject; // 3180 win, 2a60 android32, 31a8 android64
-	PAD = win 0x60, android32 0x38, android64 0x60, mac 0x60;
+	PAD = win 0x60, android32 0x38, android64 0x60, mac 0x60, ios 0x60;
 	bool m_isPracticeMode;
 	bool m_practiceMusicSync;
 	float m_loadingProgress;
@@ -7847,11 +7847,11 @@ class GJBaseGameLayer : cocos2d::CCLayer, TriggerEffectDelegate {
 	bool m_unk3234;
 	cocos2d::CCParticleSystemQuad* m_unk3238;
 	int m_unk323c;
-	PAD = win 0x6, android32 0x10, android64 0x6, mac 0x6; // mac not verified
+	PAD = win 0x6, android32 0x10, android64 0x6, mac 0x6, ios 0x6; // mac not verified
 	bool m_started;
-	PAD = win 0xA6, android32 0x66, android64 0x8e, mac 0xa0;
+	PAD = win 0xA6, android32 0x66, android64 0x8e, mac 0xa0, ios 0xa0;
 	gd::vector<PlayerButtonCommand> m_queuedButtons;
-	PAD = win 0x148, android32 0xa0, android64 0x138, mac 0x118;
+	PAD = win 0x148, android32 0xa0, android64 0x138, mac 0x118, ios 0x118;
 	cocos2d::CCDictionary* m_unk3458;
 	int m_unk3460;
 	UILayer* m_uiLayer;
@@ -7860,19 +7860,19 @@ class GJBaseGameLayer : cocos2d::CCLayer, TriggerEffectDelegate {
 	cocos2d::CCNode* m_unk3480;
 	double m_timePlayed;
 	bool m_levelEndAnimationStarted;
-	PAD = win 0x7, android32 0x0, android64 0x0, mac 0x0;
+	PAD = win 0x7, android32 0x0, android64 0x0, mac 0x0, ios 0x0;
 	bool m_cantPause;
-	PAD = win 0x18, android32 0x7, android64 0x7, mac 0x30;
+	PAD = win 0x18, android32 0x7, android64 0x7, mac 0x30, ios 0x30;
 	gd::vector<gd::vector<gd::vector<GameObject*>*>*> m_sections;
-	PAD = win 0x90, android32 0x48, android64 0x90, mac 0x90;
+	PAD = win 0x90, android32 0x48, android64 0x90, mac 0x90, ios 0x90;
 	gd::vector<gd::vector<int>*> m_sectionSizes;
-	PAD = win 0x70, android32 0x38, android64 0x68, mac 0x40; // mac not verified
+	PAD = win 0x70, android32 0x38, android64 0x68, mac 0x40, ios 0x40; // mac not verified
 	gd::vector<gd::vector<int>*> m_nonEffectObjectsPerSection;
-	PAD = win 0x10, android32 0xc, android64 0x10, mac 0x10;
+	PAD = win 0x10, android32 0xc, android64 0x10, mac 0x10, ios 0x10;
 	FMODLevelVisualizer* m_audioVisualizerBG;
 	FMODLevelVisualizer* m_audioVisualizerSFX;
 	bool m_showAudioVisualizer;
-	PAD = win 0x67, android32 0x67, android64 0x67, mac 0x67;
+	PAD = win 0x67, android32 0x67, android64 0x67, mac 0x67, ios 0x67;
 	GJGameLoadingLayer* m_loadingLayer;
 	cocos2d::CCDrawNode* m_debugDrawNode;
 	void* m_unk3678;

--- a/test/members/iOS.cpp
+++ b/test/members/iOS.cpp
@@ -3,32 +3,32 @@
 #ifdef GEODE_IS_IOS
 
 // GEODE_SIZE_CHECK(PlayLayer, 0x3790);
-GEODE_MEMBER_CHECK(PlayLayer, m_coinArray, 0x2f40);
-GEODE_MEMBER_CHECK(PlayLayer, m_unkSomeFloat, 0x2f5c);
-GEODE_MEMBER_CHECK(PlayLayer, m_jumps, 0x2fe0);
-GEODE_MEMBER_CHECK(PlayLayer, m_hasCompletedLevel, 0x2fed);
-GEODE_MEMBER_CHECK(PlayLayer, m_endLayerStars, 0x2ff4);
-GEODE_MEMBER_CHECK(PlayLayer, m_isPaused, 0x3000);
+GEODE_MEMBER_CHECK(PlayLayer, m_coinArray, 0x3508);
+GEODE_MEMBER_CHECK(PlayLayer, m_unkSomeFloat, 0x35a4);
+GEODE_MEMBER_CHECK(PlayLayer, m_jumps, 0x3680);
+GEODE_MEMBER_CHECK(PlayLayer, m_hasCompletedLevel, 0x368D);
+GEODE_MEMBER_CHECK(PlayLayer, m_endLayerStars, 0x3694);
+GEODE_MEMBER_CHECK(PlayLayer, m_isPaused, 0x36F7);
 
-GEODE_MEMBER_CHECK(LevelEditorLayer, m_trailTimer, 0x2ff0);
+GEODE_MEMBER_CHECK(LevelEditorLayer, m_trailTimer, 0x35b8);
 
 // GEODE_SIZE_CHECK(FMODAudioEngine, 0x648);
 GEODE_MEMBER_CHECK(FMODAudioEngine, m_system, 0x1e8);
 
 
-GEODE_SIZE_CHECK(GJBaseGameLayer, 0x2ef8);
-GEODE_MEMBER_CHECK(GJBaseGameLayer, m_groupDict, 0xd08);
-GEODE_MEMBER_CHECK(GJBaseGameLayer, m_massiveFloatArray, 0xe30);
-GEODE_MEMBER_CHECK(GJBaseGameLayer, m_attempts, 0x2d70);
-GEODE_MEMBER_CHECK(GJBaseGameLayer, m_shaderLayer, 0x2da0);
-GEODE_MEMBER_CHECK(GJBaseGameLayer, m_startPosObject, 0x2db0);
-GEODE_MEMBER_CHECK(GJBaseGameLayer, m_isPracticeMode, 0x2db8);
-GEODE_MEMBER_CHECK(GJBaseGameLayer, m_queuedButtons, 0x2e18);
-GEODE_MEMBER_CHECK(GJBaseGameLayer, m_unk3458, 0x2e30);
-GEODE_MEMBER_CHECK(GJBaseGameLayer, m_uiLayer, 0x2e40);
-GEODE_MEMBER_CHECK(GJBaseGameLayer, m_sections, 0x2e70);
-GEODE_MEMBER_CHECK(GJBaseGameLayer, m_audioVisualizerBG, 0x2eb8);
-GEODE_MEMBER_CHECK(GJBaseGameLayer, m_loadingLayer, 0x2ed0);
+GEODE_SIZE_CHECK(GJBaseGameLayer, 0x34c0);
+GEODE_MEMBER_CHECK(GJBaseGameLayer, m_groupDict, 0xde0);
+GEODE_MEMBER_CHECK(GJBaseGameLayer, m_massiveFloatArray, 0xf6c);
+GEODE_MEMBER_CHECK(GJBaseGameLayer, m_attempts, 0x2f14);
+GEODE_MEMBER_CHECK(GJBaseGameLayer, m_shaderLayer, 0x2fd8);
+GEODE_MEMBER_CHECK(GJBaseGameLayer, m_startPosObject, 0x2fe8);
+GEODE_MEMBER_CHECK(GJBaseGameLayer, m_isPracticeMode, 0x3050);
+GEODE_MEMBER_CHECK(GJBaseGameLayer, m_queuedButtons, 0x3158);
+GEODE_MEMBER_CHECK(GJBaseGameLayer, m_unk3458, 0x3288);
+GEODE_MEMBER_CHECK(GJBaseGameLayer, m_uiLayer, 0x3298);
+GEODE_MEMBER_CHECK(GJBaseGameLayer, m_sections, 0x32f8);
+GEODE_MEMBER_CHECK(GJBaseGameLayer, m_audioVisualizerBG, 0x3420);
+GEODE_MEMBER_CHECK(GJBaseGameLayer, m_loadingLayer, 0x3498);
 
 
 // GEODE_SIZE_CHECK(PlayerObject, 0xbe8); 


### PR DESCRIPTION
Derived from macOS paddings, I came to the conclusion that I should do that when I checked to see that GJBaseGameLayer, PlayLayer, and LevelEditorLayer were the same size on macOS and iOS