### PR TITLE
Fix typo in MoreOptionsLayer::goToPage on MacOS Intel

### DIFF
--- a/bindings/2.206/GeometryDash.bro
+++ b/bindings/2.206/GeometryDash.bro
@@ -13266,7 +13266,7 @@ class MoreOptionsLayer : FLAlertLayer, TextInputDelegate, GooglePlayDelegate, GJ
 
 	void addToggle(char const*, char const*, char const*) = win 0x353280, ios 0xf00d0, imac 0x7a8ca0, m1 0x6b004c;
 	int countForPage(int) = win 0x3538e0;
-	void goToPage(int) = win 0x353d00, ios 0xf07e4, m1 0x6b0bc8, imac 0x789860;
+	void goToPage(int) = win 0x353d00, ios 0xf07e4, m1 0x6b0bc8, imac 0x7a9860;
 	void incrementCountForPage(int);
 	const char* infoKey(int);
 	cocos2d::CCLayer* layerForPage(int) = win 0x353b40;


### PR DESCRIPTION
I mistyped something in MoreOptionsLayer::goToPage on MacOS Intel