### PR TITLE
Return Types and Class Members for ObjectManager & Fixes For CCExtenderNode

### DIFF
--- a/bindings/2.2074/GeometryDash.bro
+++ b/bindings/2.2074/GeometryDash.bro
@@ -1154,8 +1154,8 @@ class CCCounterLabel : cocos2d::CCLabelBMFont {
 }
 
 [[link(android)]]
-class CCExtenderNode {
-    void setOpacity(unsigned int);
+class CCExtenderNode : cocos2d::CCNode {
+    void setOpacity(unsigned int opacity);
 }
 
 [[link(android)]]

--- a/bindings/2.2074/GeometryDash.bro
+++ b/bindings/2.2074/GeometryDash.bro
@@ -14188,17 +14188,20 @@ class ObjectManager : cocos2d::CCNode {
     static ObjectManager* instance() = win 0x6e3d0;
     // virtual ~ObjectManager();
 
-    TodoReturn animLoaded(char const*);
-    TodoReturn getDefinition(char const*);
-    TodoReturn getGlobalAnimCopy(char const*);
-    TodoReturn loadCopiedAnimations() = win 0x6e800;
-    TodoReturn loadCopiedSets();
-    TodoReturn purgeObjectManager();
-    TodoReturn replaceAllOccurencesOfString(cocos2d::CCString*, cocos2d::CCString*, cocos2d::CCDictionary*);
-    void setLoaded(char const*);
+    cocos2d::CCObject* animLoaded(char const* anim);
+    cocos2d::CCObject* getDefinition(char const* definitionKey);
+    cocos2d::CCObject* getGlobalAnimCopy(char const* anim);
+    void loadCopiedAnimations() = win 0x6e800;
+    void loadCopiedSets();
+    void purgeObjectManager();
+    cocos2d::CCDictionary* replaceAllOccurencesOfString(cocos2d::CCString*, cocos2d::CCString*, cocos2d::CCDictionary*);
+    void setLoaded(char const* objectName);
     void setup() = win 0x6e4c0;
 
     virtual bool init() = win 0x6e460, m1 0x69410c, imac 0x77f750, ios 0x24c270;
+
+    cocos2d::CCDictionary* m_objectDefinitions;
+    cocos2d::CCDictionary* m_maybeLoadedAnimations;
 }
 
 [[link(android)]]


### PR DESCRIPTION
As I was going through CCAnimateFrameCache Since I was trying to solve CCPartAnimSprite. The ObjectManager Appeared in CCAnimateFrameCache which has many interactions with CCPartAnimSprite so getting ObjectManager out of the way first became  a priority over everything else for me. Hopefully I named off the class members correctly because ObjectManager's code is not going to be an easy one to crack open mainly due to it's length of code.

Anyways hopefully you'll at least enjoy what I've found so far.