### PR TITLE
Add 2 Missing Class Members into ShaderLayer

### DIFF
--- a/bindings/2.2074/GeometryDash.bro
+++ b/bindings/2.2074/GeometryDash.bro
@@ -18592,6 +18592,8 @@ class ShaderLayer : cocos2d::CCLayer {
     cocos2d::CCSize m_targetTextureSizeExtra;
     int m_textureScaleUniform;
     int m_textureScaleInvUniform;
+    int m_screenAspectUniform;
+    int m_screenAspectINVUniform;
     int m_shaderPositionUniform;
     int m_blurRefColorUniform;
     int m_blurUseRefUniform;


### PR DESCRIPTION
I found 2 missing class members on ghidra where m_screenAspectUniform and m_screenAspectINVUniform were not named off causing the class member offsets while reverse engineering ShaderLayer to be completely wrong. Naming these two variables off fixed things for me on the android 32 bit version. 
![image](https://github.com/user-attachments/assets/8da26381-f2b7-4643-8f34-0ab20a96a4c4)
