### PR TITLE
Don't mark undefined functions as private

### DIFF
--- a/bindings/2.2074/Cocos2d.bro
+++ b/bindings/2.2074/Cocos2d.bro
@@ -220,7 +220,7 @@ class cocos2d::CCEaseBackInOut : cocos2d::CCActionEase {
 
 [[link(win, android)]]
 class cocos2d::CCEaseBounce : cocos2d::CCActionEase {
-    static cocos2d::CCEaseBounce* create(cocos2d::CCActionInterval*) {
+    static cocos2d::CCEaseBounce* create(cocos2d::CCActionInterval* pAction) = ios inline {
         CCEaseBounce *pRet = new CCEaseBounce();
         if (pRet)
         {

--- a/bindings/2.2074/Cocos2d.bro
+++ b/bindings/2.2074/Cocos2d.bro
@@ -161,7 +161,7 @@ class cocos2d::CCEaseBackOut : cocos2d::CCActionEase {
 [[link(win, android)]]
 class cocos2d::CCEaseBackInOut : cocos2d::CCActionEase {
     static cocos2d::CCEaseBackInOut* create(cocos2d::CCActionInterval* pAction) = m1 0x460fd8, imac 0x501630, ios inline {
-	CCEaseBackInOut *pRet = new CCEaseBackInOut();
+        CCEaseBackInOut *pRet = new CCEaseBackInOut();
         if (pRet)
         {
             if (pRet->initWithAction(pAction))
@@ -181,7 +181,7 @@ class cocos2d::CCEaseBackInOut : cocos2d::CCActionEase {
     // CCEaseBackInOut();
 
     virtual cocos2d::CCObject* copyWithZone(cocos2d::CCZone* pZone) = m1 0x461080, imac 0x5016d0, ios inline {
-	CCZone* pNewZone = NULL;
+        CCZone* pNewZone = NULL;
         CCEaseBackInOut* pCopy = NULL;
         if(pZone && pZone->m_pCopyObject) 
         {
@@ -200,7 +200,7 @@ class cocos2d::CCEaseBackInOut : cocos2d::CCActionEase {
         return pCopy;
     }
     virtual void update(float time) = m1 0x461168, imac 0x5017d0, ios inline {
-	float overshoot = 1.70158f * 1.525f;
+        float overshoot = 1.70158f * 1.525f;
 
         time = time * 2;
         if (time < 1)
@@ -214,7 +214,7 @@ class cocos2d::CCEaseBackInOut : cocos2d::CCActionEase {
         }
     }
     virtual cocos2d::CCActionInterval* reverse() = m1 0x4611fc, imac 0x501860, ios inline {
-	return CCEaseBackInOut::create(m_pInner->reverse());
+        return CCEaseBackInOut::create(m_pInner->reverse());
     }
 }
 
@@ -227,8 +227,25 @@ class cocos2d::CCEaseBounce : cocos2d::CCActionEase {
 
     float bounceTime(float) = ios 0x26bea4;
 
-    virtual cocos2d::CCObject* copyWithZone(cocos2d::CCZone*) = m1 0x4600c4, imac 0x5007d0;
-    virtual cocos2d::CCActionInterval* reverse() = m1 0x460294, imac 0x500990;
+    virtual cocos2d::CCObject* copyWithZone(cocos2d::CCZone*) = m1 0x4600c4, imac 0x5007d0, ios inline {
+        CCEaseBounce *pRet = new CCEaseBounce();
+        if (pRet)
+        {
+            if (pRet->initWithAction(pAction))
+            {
+                pRet->autorelease();
+            }
+            else
+            {
+                CC_SAFE_RELEASE_NULL(pRet);
+            }
+        }
+
+        return pRet; 
+    }
+    virtual cocos2d::CCActionInterval* reverse() = m1 0x460294, imac 0x500990, ios inline {
+        return CCEaseBounce::create(m_pInner->reverse());
+    }
 }
 
 [[link(win, android)]]
@@ -258,7 +275,7 @@ class cocos2d::CCEaseBounceOut : cocos2d::CCEaseBounce {
 [[link(win, android)]]
 class cocos2d::CCEaseBounceInOut : cocos2d::CCEaseBounce {
     static cocos2d::CCEaseBounceInOut* create(cocos2d::CCActionInterval* pAction) = m1 0x46082c, imac 0x500ed0, ios inline {
-	CCEaseBounceInOut *pRet = new CCEaseBounceInOut();
+        CCEaseBounceInOut *pRet = new CCEaseBounceInOut();
         if (pRet)
         {
             if (pRet->initWithAction(pAction))
@@ -278,7 +295,7 @@ class cocos2d::CCEaseBounceInOut : cocos2d::CCEaseBounce {
     // CCEaseBounceInOut();
 
     virtual cocos2d::CCObject* copyWithZone(cocos2d::CCZone* pZone) = m1 0x4608d4, imac 0x500f70, ios inline {
-	CCZone* pNewZone = NULL;
+        CCZone* pNewZone = NULL;
         CCEaseBounceInOut* pCopy = NULL;
         if(pZone && pZone->m_pCopyObject) 
         {
@@ -297,7 +314,7 @@ class cocos2d::CCEaseBounceInOut : cocos2d::CCEaseBounce {
         return pCopy;
     }
     virtual void update(float time) = m1 0x4609bc, imac 0x501070, ios inline {
-	float newT = 0;
+        float newT = 0;
         if (time < 0.5f)
         {
             time = time * 2;
@@ -311,7 +328,7 @@ class cocos2d::CCEaseBounceInOut : cocos2d::CCEaseBounce {
         m_pInner->update(newT);
     }
     virtual cocos2d::CCActionInterval* reverse() = m1 0x460be4, imac 0x501220, ios inline {
-	return CCEaseBounceInOut::create(m_pInner->reverse());
+        return CCEaseBounceInOut::create(m_pInner->reverse());
     }
 }
 
@@ -876,7 +893,28 @@ class cocos2d::CCScaleBy : cocos2d::CCScaleTo {
     // CCScaleBy(cocos2d::CCScaleBy const&);
     // CCScaleBy();
 
-    virtual cocos2d::CCObject* copyWithZone(cocos2d::CCZone*) = m1 0x333b0c, imac 0x3a75c0;
+    virtual cocos2d::CCObject* copyWithZone(cocos2d::CCZone* pZone) = m1 0x333b0c, imac 0x3a75c0, ios inline {
+        CCZone* pNewZone = NULL;
+        CCScaleTo* pCopy = NULL;
+        if(pZone && pZone->m_pCopyObject)
+        {
+            //in case of being called at sub class
+            pCopy = (CCScaleBy*)(pZone->m_pCopyObject);
+        }
+        else
+        {
+            pCopy = new CCScaleBy();
+            pZone = pNewZone = new CCZone(pCopy);
+        }
+
+        CCScaleTo::copyWithZone(pZone);
+
+
+        pCopy->initWithDuration(m_fDuration, m_fEndScaleX, m_fEndScaleY);
+        
+        CC_SAFE_DELETE(pNewZone);
+        return pCopy;
+    }
     virtual void startWithTarget(cocos2d::CCNode* pTarget) = m1 0x333c04, imac 0x3a76d0, ios inline {
         cocos2d::CCScaleTo::startWithTarget(pTarget);
         m_fDeltaX = m_fStartScaleX * m_fEndScaleX - m_fStartScaleX;
@@ -1186,7 +1224,9 @@ class cocos2d::CCFiniteTimeAction : cocos2d::CCAction {
     // CCFiniteTimeAction(cocos2d::CCFiniteTimeAction const&);
     // CCFiniteTimeAction();
 
-    virtual cocos2d::CCFiniteTimeAction* reverse() = m1 0x50fb68, imac 0x5dcc40;
+    virtual cocos2d::CCFiniteTimeAction* reverse() = m1 0x50fb68, imac 0x5dcc40, ios inline {
+        return nullptr;
+    }
 }
 
 [[link(win, android)]]
@@ -4088,11 +4128,11 @@ class cocos2d::CCMenuItemSprite : cocos2d::CCMenuItem {
     virtual void selected() = imac 0x3ad0c0, m1 0x338e40, ios 0x50ab0;
     virtual void unselected() = imac 0x3ad160, m1 0x338ecc, ios 0x50b3c;
     virtual void setEnabled(bool) = imac 0x3ad1e0, m1 0x338f4c, ios 0x50bbc;
-    virtual cocos2d::CCNode* getNormalImage() = m1 0x338964, imac 0x3acc10, ios 0x50764; // i actually like have no idea if this is correct. Somebody check the binding im too lazy
+    virtual cocos2d::CCNode* getNormalImage() = m1 0x338964, imac 0x3acc10, ios 0x50764;
     virtual void setNormalImage(cocos2d::CCNode*) = imac 0x3acc20, m1 0x33896c, ios 0x5076c;
-    virtual cocos2d::CCNode* getSelectedImage() = m1 0x338a38, imac 0x3acce0;
+    virtual cocos2d::CCNode* getSelectedImage() = m1 0x338a38, imac 0x3acce0, ios 0x50838;
     virtual void setSelectedImage(cocos2d::CCNode*) = imac 0x3accf0, m1 0x338a40, ios 0x50840;
-    virtual cocos2d::CCNode* getDisabledImage() = m1 0x338ae8, imac 0x3acd80;
+    virtual cocos2d::CCNode* getDisabledImage() = m1 0x338ae8, imac 0x3acd80, ios 0x508e8;
     virtual void setDisabledImage(cocos2d::CCNode*) = imac 0x3acd90, m1 0x338af0, ios 0x508f0;
     virtual void updateImagesVisibility() = imac 0x3ad200, m1 0x338f6c, ios 0x50bdc;
 }

--- a/bindings/2.2074/Cocos2d.bro
+++ b/bindings/2.2074/Cocos2d.bro
@@ -4502,9 +4502,9 @@ class cocos2d::extension::CCScale9Sprite : cocos2d::CCNodeRGBA {
     virtual bool init() = m1 0x364478, imac 0x3e2060, ios 0x21536c;
     virtual void setContentSize(const cocos2d::CCSize& size) = m1 0x365484, imac 0x3e3190, ios 0x216264;
     virtual void visit() = imac 0x3e44d0, m1 0x3667fc, ios 0x216f54;
-    virtual GLubyte getOpacity() = m1 0x366b28, imac 0x3e4800, ios 0x21710c;
-    virtual void setOpacity(GLubyte opacity);
-    virtual void updateDisplayedOpacity(GLubyte parentOpacity);
+    virtual unsigned char getOpacity() = m1 0x366b28, imac 0x3e4800, ios 0x21710c;
+    virtual void setOpacity(unsigned char) = m1 0x3669c0, imac 0x3e46a0, ios 0x217058;
+    virtual void updateDisplayedOpacity(unsigned char) = m1 0x366650, imac 0x3e42a0, ios 0x216da8;
     virtual const cocos2d::ccColor3B& getColor() = m1 0x3669b0, imac 0x3e4680, ios 0x217048;
     virtual void setColor(const cocos2d::ccColor3B& color) = m1 0x366830, imac 0x3e4500, ios 0x216f88;
     virtual void updateDisplayedColor(const cocos2d::ccColor3B& parentColor) = m1 0x3666bc, imac 0x3e4310, ios 0x216e14;

--- a/bindings/2.2074/Cocos2d.bro
+++ b/bindings/2.2074/Cocos2d.bro
@@ -220,7 +220,22 @@ class cocos2d::CCEaseBackInOut : cocos2d::CCActionEase {
 
 [[link(win, android)]]
 class cocos2d::CCEaseBounce : cocos2d::CCActionEase {
-    static cocos2d::CCEaseBounce* create(cocos2d::CCActionInterval*);
+    static cocos2d::CCEaseBounce* create(cocos2d::CCActionInterval*) {
+        CCEaseBounce *pRet = new CCEaseBounce();
+        if (pRet)
+        {
+            if (pRet->initWithAction(pAction))
+            {
+                pRet->autorelease();
+            }
+            else
+            {
+                CC_SAFE_RELEASE_NULL(pRet);
+            }
+        }
+
+        return pRet; 
+    }
 
     // CCEaseBounce(cocos2d::CCEaseBounce const&);
     // CCEaseBounce();

--- a/bindings/2.2074/Cocos2d.bro
+++ b/bindings/2.2074/Cocos2d.bro
@@ -227,21 +227,24 @@ class cocos2d::CCEaseBounce : cocos2d::CCActionEase {
 
     float bounceTime(float) = ios 0x26bea4;
 
-    virtual cocos2d::CCObject* copyWithZone(cocos2d::CCZone*) = m1 0x4600c4, imac 0x5007d0, ios inline {
-        CCEaseBounce *pRet = new CCEaseBounce();
-        if (pRet)
+    virtual cocos2d::CCObject* copyWithZone(cocos2d::CCZone* pZone) = m1 0x4600c4, imac 0x5007d0, ios inline {
+        CCZone* pNewZone = NULL;
+        CCEaseBounce* pCopy = NULL;
+        if(pZone && pZone->m_pCopyObject) 
         {
-            if (pRet->initWithAction(pAction))
-            {
-                pRet->autorelease();
-            }
-            else
-            {
-                CC_SAFE_RELEASE_NULL(pRet);
-            }
+            //in case of being called at sub class
+            pCopy = (CCEaseBounce*)(pZone->m_pCopyObject);
+        }
+        else
+        {
+            pCopy = new CCEaseBounce();
+            pNewZone = new CCZone(pCopy);
         }
 
-        return pRet; 
+        pCopy->initWithAction((CCActionInterval *)(m_pInner->copy()->autorelease()));
+        
+        CC_SAFE_DELETE(pNewZone);
+        return pCopy; 
     }
     virtual cocos2d::CCActionInterval* reverse() = m1 0x460294, imac 0x500990, ios inline {
         return CCEaseBounce::create(m_pInner->reverse());

--- a/bindings/2.2074/GeometryDash.bro
+++ b/bindings/2.2074/GeometryDash.bro
@@ -635,7 +635,7 @@ class AnimatedShopKeeper : CCAnimatedSprite {
 
 [[link(android)]]
 class AnimatedSpriteDelegate {
-    virtual void animationFinished(char const*);
+    virtual void animationFinished(char const*) {}
 }
 
 [[link(android)]]
@@ -989,10 +989,10 @@ class BoomScrollLayer : cocos2d::CCLayer {
 
 [[link(android)]]
 class BoomScrollLayerDelegate {
-    virtual void scrollLayerScrollingStarted(BoomScrollLayer*);
-    virtual void scrollLayerScrolledToPage(BoomScrollLayer*, int);
-    virtual void scrollLayerMoved(cocos2d::CCPoint);
-    virtual void scrollLayerWillScrollToPage(BoomScrollLayer*, int);
+    virtual void scrollLayerScrollingStarted(BoomScrollLayer*) {}
+    virtual void scrollLayerScrolledToPage(BoomScrollLayer*, int) {}
+    virtual void scrollLayerMoved(cocos2d::CCPoint) {}
+    virtual void scrollLayerWillScrollToPage(BoomScrollLayer*, int) {}
 }
 
 [[link(android)]]
@@ -2835,7 +2835,7 @@ class ColorChannelSprite : cocos2d::CCSprite {
 
 [[link(android)]]
 class ColorSelectDelegate {
-    virtual void colorSelectClosed(cocos2d::CCNode*);
+    virtual void colorSelectClosed(cocos2d::CCNode*) {}
 }
 
 [[link(android)]]
@@ -3189,7 +3189,7 @@ class ConfigureValuePopup : FLAlertLayer, TextInputDelegate {
 
 [[link(android)]]
 class ConfigureValuePopupDelegate {
-    virtual void valuePopupClosed(ConfigureValuePopup*, float);
+    virtual void valuePopupClosed(ConfigureValuePopup*, float) {}
 }
 
 [[link(android)]]
@@ -8233,7 +8233,7 @@ class GameOptionsTrigger : EffectGameObject {
 
 [[link(android)]]
 class GameRateDelegate {
-    virtual void updateRate();
+    virtual void updateRate() {}
 }
 
 [[link(android)]]
@@ -8853,8 +8853,8 @@ class GJAccountRegisterDelegate {
 
 [[link(android)]]
 class GJAccountSettingsDelegate {
-    virtual void updateSettingsFinished();
-    virtual void updateSettingsFailed();
+    virtual void updateSettingsFinished() {}
+    virtual void updateSettingsFailed() {}
 }
 
 [[link(android)]]
@@ -9907,8 +9907,8 @@ class GJBigSpriteNode : cocos2d::CCNode {
 
 [[link(android)]]
 class GJChallengeDelegate {
-    virtual void challengeStatusFinished();
-    virtual void challengeStatusFailed();
+    virtual void challengeStatusFinished() {}
+    virtual void challengeStatusFailed() {}
 }
 
 [[link(android)]]
@@ -11668,7 +11668,7 @@ class GJPromoPopup : FLAlertLayer {
 
 [[link(android)]]
 class GJPurchaseDelegate {
-    virtual void didPurchaseItem(GJStoreItem*);
+    virtual void didPurchaseItem(GJStoreItem*) {}
 }
 
 [[link(android)]]
@@ -11699,8 +11699,8 @@ class GJRequestCell : TableViewCell, FLAlertLayerProtocol, UploadPopupDelegate, 
 
 [[link(android)]]
 class GJRewardDelegate {
-    virtual void rewardsStatusFinished(int);
-    virtual void rewardsStatusFailed();
+    virtual void rewardsStatusFinished(int) {}
+    virtual void rewardsStatusFailed() {}
 }
 
 [[link(android)]]
@@ -12602,7 +12602,7 @@ class GJSpecialColorSelect : FLAlertLayer {
 
 [[link(android)]]
 class GJSpecialColorSelectDelegate {
-    virtual void colorSelectClosed(GJSpecialColorSelect*, int);
+    virtual void colorSelectClosed(GJSpecialColorSelect*, int) {}
 }
 
 [[link(android)]]
@@ -12730,22 +12730,22 @@ class GJTransformControl : cocos2d::CCLayer {
 
 [[link(android)]]
 class GJTransformControlDelegate {
-    virtual void transformScaleXChanged(float);
-    virtual void transformScaleYChanged(float);
-    virtual void transformScaleXYChanged(float, float);
-    virtual void transformRotationXChanged(float);
-    virtual void transformRotationYChanged(float);
-    virtual void transformRotationChanged(float);
-    virtual void transformResetRotation();
-    virtual void transformRestoreRotation();
-    virtual void transformSkewXChanged(float);
-    virtual void transformSkewYChanged(float);
-    virtual void transformChangeBegin();
-    virtual void transformChangeEnded();
-    virtual void updateTransformControl();
-    virtual void anchorPointMoved(cocos2d::CCPoint);
-    virtual cocos2d::CCNode* getTransformNode();
-    virtual EditorUI* getUI();
+    virtual void transformScaleXChanged(float) {}
+    virtual void transformScaleYChanged(float) {}
+    virtual void transformScaleXYChanged(float, float) {}
+    virtual void transformRotationXChanged(float) {}
+    virtual void transformRotationYChanged(float) {}
+    virtual void transformRotationChanged(float) {}
+    virtual void transformResetRotation() {}
+    virtual void transformRestoreRotation() {}
+    virtual void transformSkewXChanged(float) {}
+    virtual void transformSkewYChanged(float) {}
+    virtual void transformChangeBegin() {}
+    virtual void transformChangeEnded() {}
+    virtual void updateTransformControl() {}
+    virtual void anchorPointMoved(cocos2d::CCPoint) {}
+    virtual cocos2d::CCNode* getTransformNode() { return nullptr; }
+    virtual EditorUI* getUI() { return nullptr; }
 }
 
 [[link(android)]]
@@ -15202,7 +15202,7 @@ class ListButtonBar : cocos2d::CCNode {
 
 [[link(android)]]
 class ListButtonBarDelegate {
-    virtual void listButtonBarSwitchedPage(ListButtonBar*, int);
+    virtual void listButtonBarSwitchedPage(ListButtonBar*, int) {}
 }
 
 [[link(android)]]
@@ -15230,8 +15230,8 @@ class ListCell : TableViewCell {
 
 [[link(android)]]
 class ListUploadDelegate {
-    virtual void listUploadFinished(GJLevelList*);
-    virtual void listUploadFailed(GJLevelList*, int);
+    virtual void listUploadFinished(GJLevelList*) {}
+    virtual void listUploadFailed(GJLevelList*, int) {}
 }
 
 [[link(android)]]
@@ -18025,8 +18025,8 @@ class RetryLevelLayer : GJDropDownLayer, RewardedVideoDelegate {
 
 [[link(android)]]
 class RewardedVideoDelegate {
-    virtual void rewardedVideoFinished();
-    virtual bool shouldOffsetRewardCurrency();
+    virtual void rewardedVideoFinished() {}
+    virtual bool shouldOffsetRewardCurrency() { return false; }
 }
 
 [[link(android)]]
@@ -18675,9 +18675,6 @@ class SecretLayer5 : cocos2d::CCLayer, TextInputDelegate, FLAlertLayerProtocol, 
 [[link(android)]]
 class SecretLayer6 : cocos2d::CCLayer {
     // virtual ~SecretLayer6() = m1 0x3db294, imac 0x64bc50;
-    SecretLayer6() = win inline {
-        m_gameLayer = nullptr;
-    }
 
     static SecretLayer6* create() = m1 0x3db37c, imac 0x46bd70;
     static cocos2d::CCScene* scene() = m1 0x3db2c0, imac 0x46bca0;
@@ -19005,7 +19002,7 @@ class SelectSettingLayer : FLAlertLayer {
 
 [[link(android)]]
 class SelectSFXSortDelegate {
-    virtual void sortSelectClosed(SelectSFXSortLayer*);
+    virtual void sortSelectClosed(SelectSFXSortLayer*) {}
 }
 
 [[link(android)]]
@@ -21901,7 +21898,7 @@ class ShardsPage : FLAlertLayer {
 
 [[link(android)]]
 class ShareCommentDelegate {
-    virtual void shareCommentClosed(gd::string, ShareCommentLayer*);
+    virtual void shareCommentClosed(gd::string, ShareCommentLayer*) {}
 }
 
 [[link(android)]]
@@ -22864,7 +22861,7 @@ class SpriteDescription : cocos2d::CCObject {
 
 [[link(android)]]
 class SpritePartDelegate {
-    virtual void displayFrameChanged(cocos2d::CCObject*, gd::string);
+    virtual void displayFrameChanged(cocos2d::CCObject*, gd::string) {}
 }
 
 [[link(android)]]
@@ -23099,10 +23096,10 @@ class TableViewCell : cocos2d::CCLayer {
 
 [[link(android)]]
 class TableViewCellDelegate {
-    virtual bool cellPerformedAction(TableViewCell*, int, CellAction, cocos2d::CCNode*);
-    virtual int getSelectedCellIdx();
-    virtual bool shouldSnapToSelected();
-    virtual int getCellDelegateType();
+    virtual bool cellPerformedAction(TableViewCell*, int, CellAction, cocos2d::CCNode*) { return false; }
+    virtual int getSelectedCellIdx() { return 0; }
+    virtual bool shouldSnapToSelected() { return true; }
+    virtual int getCellDelegateType() { return 0; }
 }
 
 [[link(android)]]

--- a/bindings/2.2074/GeometryDash.bro
+++ b/bindings/2.2074/GeometryDash.bro
@@ -3030,7 +3030,7 @@ class ColorSelectPopup : SetupTriggerPopup, cocos2d::extension::ColorPickerDeleg
 
 [[link(android)]]
 class ColorSetupDelegate {
-    virtual void colorSetupClosed(int);
+    virtual void colorSetupClosed(int) {}
 }
 
 [[link(android)]]
@@ -3065,8 +3065,8 @@ class CommentCell : TableViewCell, LikeItemDelegate, FLAlertLayerProtocol {
 
 [[link(android)]]
 class CommentUploadDelegate {
-    virtual void commentUploadFinished(int);
-    virtual void commentUploadFailed(int, CommentError);
+    virtual void commentUploadFinished(int) {}
+    virtual void commentUploadFailed(int, CommentError) {}
     virtual void commentDeleteFailed(int, int) {}
 }
 
@@ -3768,9 +3768,9 @@ class CustomSFXCell : TableViewCell, CustomSFXDelegate {
 
 [[link(android)]]
 class CustomSFXDelegate {
-    virtual void sfxObjectSelected(SFXInfoObject*);
-    virtual int getActiveSFXID();
-    virtual bool overridePlaySFX(SFXInfoObject*);
+    virtual void sfxObjectSelected(SFXInfoObject*) {}
+    virtual int getActiveSFXID() { return 0; }
+    virtual bool overridePlaySFX(SFXInfoObject*) { return false; }
 }
 
 [[link(android)]]
@@ -3866,8 +3866,8 @@ class CustomSongCell : TableViewCell, CustomSongDelegate {
 
 [[link(android)]]
 class CustomSongDelegate {
-    virtual void songIDChanged(int);
-    virtual int getActiveSongID();
+    virtual void songIDChanged(int) {}
+    virtual int getActiveSongID() {}
     virtual gd::string getSongFileName();
     virtual LevelSettingsObject* getLevelSettings();
 }
@@ -4304,8 +4304,8 @@ class DialogObject : cocos2d::CCObject {
 
 [[link(android)]]
 class DownloadMessageDelegate {
-    virtual void downloadMessageFinished(GJUserMessage*);
-    virtual void downloadMessageFailed(int);
+    virtual void downloadMessageFinished(GJUserMessage*) {}
+    virtual void downloadMessageFailed(int) {}
 }
 
 [[link(android)]]
@@ -6501,10 +6501,10 @@ class FRequestProfilePage : FLAlertLayer, FLAlertLayerProtocol, UploadActionDele
 
 [[link(android)]]
 class FriendRequestDelegate {
-    virtual void loadFRequestsFinished(cocos2d::CCArray*, char const*);
-    virtual void loadFRequestsFailed(char const*, GJErrorCode);
-    virtual void setupPageInfo(gd::string, char const*);
-    virtual void forceReloadRequests(bool);
+    virtual void loadFRequestsFinished(cocos2d::CCArray*, char const*) {}
+    virtual void loadFRequestsFailed(char const*, GJErrorCode) {}
+    virtual void setupPageInfo(gd::string, char const*) {}
+    virtual void forceReloadRequests(bool) {}
 }
 
 [[link(android)]]
@@ -8769,19 +8769,19 @@ class GhostTrailEffect : cocos2d::CCNode {
 
 [[link(android)]]
 class GJAccountBackupDelegate {
-    virtual void backupAccountFinished();
-    virtual void backupAccountFailed(BackupAccountError, int);
+    virtual void backupAccountFinished() {}
+    virtual void backupAccountFailed(BackupAccountError, int) {}
 }
 
 [[link(android)]]
 class GJAccountDelegate {
-    virtual void accountStatusChanged();
+    virtual void accountStatusChanged() {}
 }
 
 [[link(android)]]
 class GJAccountLoginDelegate {
-    virtual void loginAccountFinished(int, int);
-    virtual void loginAccountFailed(AccountError);
+    virtual void loginAccountFinished(int, int) {}
+    virtual void loginAccountFailed(AccountError) {}
 }
 
 [[link(android)]]
@@ -8847,8 +8847,8 @@ class GJAccountManager : cocos2d::CCNode {
 
 [[link(android)]]
 class GJAccountRegisterDelegate {
-    virtual void registerAccountFinished();
-    virtual void registerAccountFailed(AccountError);
+    virtual void registerAccountFinished() {}
+    virtual void registerAccountFailed(AccountError) {}
 }
 
 [[link(android)]]
@@ -8919,8 +8919,8 @@ class GJAccountSettingsLayer : FLAlertLayer, TextInputDelegate {
 
 [[link(android)]]
 class GJAccountSyncDelegate {
-    virtual void syncAccountFinished();
-    virtual void syncAccountFailed(BackupAccountError, int);
+    virtual void syncAccountFinished() {}
+    virtual void syncAccountFailed(BackupAccountError, int) {}
 }
 
 [[link(android)]]
@@ -10033,8 +10033,8 @@ class GJCommentListLayer : cocos2d::CCLayerColor {
 
 [[link(android)]]
 class GJDailyLevelDelegate {
-    virtual void dailyStatusFinished(GJTimedLevelType);
-    virtual void dailyStatusFailed(GJTimedLevelType, GJErrorCode);
+    virtual void dailyStatusFinished(GJTimedLevelType) {}
+    virtual void dailyStatusFailed(GJTimedLevelType, GJErrorCode) {}
 }
 
 [[link(android)]]
@@ -11403,10 +11403,10 @@ class GJMoreGamesLayer : GJDropDownLayer {
 
 [[link(android)]]
 class GJMPDelegate {
-    virtual void joinLobbyFinished(int);
-    virtual void joinLobbyFailed(int, GJMPErrorCode);
-    virtual void didUploadMPComment(int);
-    virtual void updateComments();
+    virtual void joinLobbyFinished(int) {}
+    virtual void joinLobbyFailed(int, GJMPErrorCode) {}
+    virtual void didUploadMPComment(int) {}
+    virtual void updateComments() {}
 }
 
 [[link(android)]]
@@ -18801,7 +18801,7 @@ class SecretRewardsLayer : cocos2d::CCLayer, DialogDelegate, BoomScrollLayerDele
 
 [[link(android)]]
 class SelectArtDelegate {
-    virtual void selectArtClosed(SelectArtLayer*);
+    virtual void selectArtClosed(SelectArtLayer*) {}
 }
 
 [[link(android)]]
@@ -18919,7 +18919,7 @@ class SelectListIconLayer : FLAlertLayer {
 
 [[link(android)]]
 class SelectPremadeDelegate {
-    virtual void selectPremadeClosed(SelectPremadeLayer*, int);
+    virtual void selectPremadeClosed(SelectPremadeLayer*, int) {}
 }
 
 [[link(android)]]
@@ -18948,7 +18948,7 @@ class SelectPremadeLayer : FLAlertLayer {
 
 [[link(android)]]
 class SelectSettingDelegate {
-    virtual void selectSettingClosed(SelectSettingLayer*);
+    virtual void selectSettingClosed(SelectSettingLayer*) {}
 }
 
 [[link(android)]]
@@ -21378,7 +21378,7 @@ class SFXBrowser : FLAlertLayer, MusicDownloadDelegate, TableViewCellDelegate, S
 
 [[link(android)]]
 class SFXBrowserDelegate {
-    virtual void sfxBrowserClosed(SFXBrowser*);
+    virtual void sfxBrowserClosed(SFXBrowser*) {}
 }
 
 [[link(android)]]
@@ -22543,7 +22543,7 @@ class SongOptionsLayer : FLAlertLayer {
 
 [[link(android)]]
 class SongPlaybackDelegate {
-    virtual void onPlayback(SongInfoObject*);
+    virtual void onPlayback(SongInfoObject*) {}
 }
 
 [[link(android)]]
@@ -23255,7 +23255,7 @@ class TextArea : cocos2d::CCSprite {
 
 [[link(android)]]
 class TextAreaDelegate {
-    virtual void fadeInTextFinished(TextArea*);
+    virtual void fadeInTextFinished(TextArea*) {}
 }
 
 [[link(android)]]
@@ -23964,8 +23964,8 @@ class UploadListPopup : FLAlertLayer, ListUploadDelegate {
 
 [[link(android)]]
 class UploadMessageDelegate {
-    virtual void uploadMessageFinished(int);
-    virtual void uploadMessageFailed(int);
+    virtual void uploadMessageFinished(int) {}
+    virtual void uploadMessageFailed(int) {}
 }
 
 [[link(android)]]
@@ -24037,17 +24037,17 @@ class URLViewLayer : GJDropDownLayer {
 
 [[link(android)]]
 class UserInfoDelegate {
-    virtual void getUserInfoFinished(GJUserScore*);
-    virtual void getUserInfoFailed(int);
-    virtual void userInfoChanged(GJUserScore*);
+    virtual void getUserInfoFinished(GJUserScore*) {}
+    virtual void getUserInfoFailed(int) {}
+    virtual void userInfoChanged(GJUserScore*) {}
 }
 
 [[link(android)]]
 class UserListDelegate {
-    virtual void getUserListFinished(cocos2d::CCArray*, UserListType);
-    virtual void getUserListFailed(UserListType, GJErrorCode);
-    virtual void userListChanged(cocos2d::CCArray*, UserListType);
-    virtual void forceReloadList(UserListType);
+    virtual void getUserListFinished(cocos2d::CCArray*, UserListType) {}
+    virtual void getUserListFailed(UserListType, GJErrorCode) {}
+    virtual void userListChanged(cocos2d::CCArray*, UserListType) {}
+    virtual void forceReloadList(UserListType) {}
 }
 
 [[link(android)]]

--- a/bindings/2.2074/GeometryDash.bro
+++ b/bindings/2.2074/GeometryDash.bro
@@ -3868,8 +3868,8 @@ class CustomSongCell : TableViewCell, CustomSongDelegate {
 class CustomSongDelegate {
     virtual void songIDChanged(int) {}
     virtual int getActiveSongID() { return 0; }
-    virtual gd::string getSongFileName();
-    virtual LevelSettingsObject* getLevelSettings();
+    virtual gd::string getSongFileName() { return ""; }
+    virtual LevelSettingsObject* getLevelSettings() { return nullptr; }
 }
 
 [[link(android)]]
@@ -4417,7 +4417,7 @@ class DynamicBitset {
 
 [[link(android)]]
 class DynamicScrollDelegate {
-    virtual void updatePageWithObject(cocos2d::CCObject* p0, cocos2d::CCObject* p1);
+    virtual void updatePageWithObject(cocos2d::CCObject* p0, cocos2d::CCObject* p1) {}
 }
 
 [[link(android)]]
@@ -23104,8 +23104,8 @@ class TableViewCellDelegate {
 
 [[link(android)]]
 class TableViewDataSource {
-    virtual int numberOfRowsInSection(unsigned int, TableView*);
-    virtual unsigned int numberOfSectionsInTableView(TableView*);
+    virtual int numberOfRowsInSection(unsigned int, TableView*) { return 0; }
+    virtual unsigned int numberOfSectionsInTableView(TableView*) { return 0; }
     virtual void TableViewCommitCellEditingStyleForRowAtIndexPath(TableView*, TableViewCellEditingStyle, CCIndexPath&) {}
     virtual TableViewCell* cellForRowAtIndexPath(CCIndexPath&, TableView*) { return nullptr; }
 }
@@ -23117,8 +23117,8 @@ class TableViewDelegate {
     virtual void TableViewWillDisplayCellForRowAtIndexPath(CCIndexPath&, TableViewCell*, TableView*) {}
     virtual void TableViewDidDisplayCellForRowAtIndexPath(CCIndexPath&, TableViewCell*, TableView*) {}
     virtual void TableViewWillReloadCellForRowAtIndexPath(CCIndexPath&, TableViewCell*, TableView*) {}
-    virtual float cellHeightForRowAtIndexPath(CCIndexPath&, TableView*);
-    virtual void didSelectRowAtIndexPath(CCIndexPath&, TableView*);
+    virtual float cellHeightForRowAtIndexPath(CCIndexPath&, TableView*) { return 0; }
+    virtual void didSelectRowAtIndexPath(CCIndexPath&, TableView*) {}
 }
 
 [[link(android)]]
@@ -23526,9 +23526,9 @@ class TriggerControlGameObject : EffectGameObject {
 
 [[link(android)]]
 class TriggerEffectDelegate {
-    virtual void toggleGroupTriggered(int, bool, gd::vector<int> const&, int, int);
-    virtual void spawnGroup(int, bool, double, gd::vector<int> const&, int, int);
-    virtual void spawnObject(GameObject*, double, gd::vector<int> const&);
+    virtual void toggleGroupTriggered(int, bool, gd::vector<int> const&, int, int) {}
+    virtual void spawnGroup(int, bool, double, gd::vector<int> const&, int, int) {}
+    virtual void spawnObject(GameObject*, double, gd::vector<int> const&) {}
 }
 
 [[link(android)]]

--- a/bindings/2.2074/GeometryDash.bro
+++ b/bindings/2.2074/GeometryDash.bro
@@ -3867,7 +3867,7 @@ class CustomSongCell : TableViewCell, CustomSongDelegate {
 [[link(android)]]
 class CustomSongDelegate {
     virtual void songIDChanged(int) {}
-    virtual int getActiveSongID() {}
+    virtual int getActiveSongID() { return 0; }
     virtual gd::string getSongFileName();
     virtual LevelSettingsObject* getLevelSettings();
 }
@@ -4417,7 +4417,7 @@ class DynamicBitset {
 
 [[link(android)]]
 class DynamicScrollDelegate {
-    virtual void updatePageWithObject(cocos2d::CCObject* p0, cocos2d::CCObject* p1) {}
+    virtual void updatePageWithObject(cocos2d::CCObject* p0, cocos2d::CCObject* p1);
 }
 
 [[link(android)]]
@@ -23104,8 +23104,8 @@ class TableViewCellDelegate {
 
 [[link(android)]]
 class TableViewDataSource {
-    virtual int numberOfRowsInSection(unsigned int, TableView*) { return 0; }
-    virtual unsigned int numberOfSectionsInTableView(TableView*) { return 0; }
+    virtual int numberOfRowsInSection(unsigned int, TableView*);
+    virtual unsigned int numberOfSectionsInTableView(TableView*);
     virtual void TableViewCommitCellEditingStyleForRowAtIndexPath(TableView*, TableViewCellEditingStyle, CCIndexPath&) {}
     virtual TableViewCell* cellForRowAtIndexPath(CCIndexPath&, TableView*) { return nullptr; }
 }
@@ -23117,8 +23117,8 @@ class TableViewDelegate {
     virtual void TableViewWillDisplayCellForRowAtIndexPath(CCIndexPath&, TableViewCell*, TableView*) {}
     virtual void TableViewDidDisplayCellForRowAtIndexPath(CCIndexPath&, TableViewCell*, TableView*) {}
     virtual void TableViewWillReloadCellForRowAtIndexPath(CCIndexPath&, TableViewCell*, TableView*) {}
-    virtual float cellHeightForRowAtIndexPath(CCIndexPath&, TableView*) { return 0; }
-    virtual void didSelectRowAtIndexPath(CCIndexPath&, TableView*) {}
+    virtual float cellHeightForRowAtIndexPath(CCIndexPath&, TableView*);
+    virtual void didSelectRowAtIndexPath(CCIndexPath&, TableView*);
 }
 
 [[link(android)]]
@@ -23526,9 +23526,9 @@ class TriggerControlGameObject : EffectGameObject {
 
 [[link(android)]]
 class TriggerEffectDelegate {
-    virtual void toggleGroupTriggered(int, bool, gd::vector<int> const&, int, int) {}
-    virtual void spawnGroup(int, bool, double, gd::vector<int> const&, int, int) {}
-    virtual void spawnObject(GameObject*, double, gd::vector<int> const&) {}
+    virtual void toggleGroupTriggered(int, bool, gd::vector<int> const&, int, int);
+    virtual void spawnGroup(int, bool, double, gd::vector<int> const&, int, int);
+    virtual void spawnObject(GameObject*, double, gd::vector<int> const&);
 }
 
 [[link(android)]]

--- a/codegen/src/BindingGen.cpp
+++ b/codegen/src/BindingGen.cpp
@@ -47,12 +47,10 @@ public:
 )GEN";
 
     constexpr char const* error_definition = R"GEN(    
-private:
     [[deprecated("{class_name}::{function_name} not implemented")]]
     /**
 {docs}{docs_addresses}     */
     {static}{virtual}{return_type} {function_name}({parameters}){const};
-public:
 )GEN";
 
     constexpr char const* structor_definition = R"GEN(

--- a/codegen/src/BindingGen.cpp
+++ b/codegen/src/BindingGen.cpp
@@ -47,10 +47,12 @@ public:
 )GEN";
 
     constexpr char const* error_definition = R"GEN(    
+private:
     [[deprecated("{class_name}::{function_name} not implemented")]]
     /**
 {docs}{docs_addresses}     */
     {static}{virtual}{return_type} {function_name}({parameters}){const};
+public:
 )GEN";
 
     constexpr char const* structor_definition = R"GEN(
@@ -265,11 +267,8 @@ std::string generateBindingHeader(Root const& root, std::filesystem::path const&
 
                 fb = &fn->prototype;
 
-                if (codegen::platformNumber(fn->binds) == -1 && codegen::getStatus(*fn) != BindStatus::Binded) {
-                    used_format = format_strings::error_definition;
-
-                    if (fb->type != FunctionType::Normal)
-                        continue;
+                if (codegen::platformNumber(fn->binds) == -1 && codegen::getStatus(*fn) != BindStatus::Binded && fb->type != FunctionType::Normal) {
+                    continue;
                 }
 
                 addressDocs = generateAddressDocs(*fn, fn->binds);

--- a/codegen/src/ModifyGen.cpp
+++ b/codegen/src/ModifyGen.cpp
@@ -153,12 +153,7 @@ std::string generateModifyHeader(Root const& root, std::filesystem::path const& 
                 continue;
             }
             else if (status == BindStatus::Unbindable && fn->prototype.type == FunctionType::Normal) {
-                if (is_cocos_or_fmod_class(c.name)) {
-                    format_string = format_strings::apply_error_defined;
-                }
-                else {
-                    format_string = format_strings::apply_error;
-                }
+                format_string = format_strings::apply_error_defined;
             }
             else if (status == BindStatus::Inlined && fn->prototype.type == FunctionType::Normal || codegen::platformNumber(fn->binds) == 0x9999999) {
                 format_string = format_strings::apply_error_inline;
@@ -179,12 +174,7 @@ std::string generateModifyHeader(Root const& root, std::filesystem::path const& 
                 }
             }
             else if (fn->prototype.type == FunctionType::Normal) {
-                if (is_cocos_or_fmod_class(c.name)) {
-                    format_string = format_strings::apply_error_defined;
-                }
-                else {
-                    format_string = format_strings::apply_error;
-                }
+                format_string = format_strings::apply_error_defined;
             }
             else {
                 continue;

--- a/codegen/src/SourceGen.cpp
+++ b/codegen/src/SourceGen.cpp
@@ -231,21 +231,13 @@ std::string generateBindingSource(Root const& root, bool skipPugixml) {
 							);
 							break;
 					}
-				} else {
+				} else if (
+					(codegen::getStatus(*fn) != BindStatus::Unbindable || codegen::platformNumber(fn->binds) != -1) &&
+					codegen::platformNumber(fn->binds) != 0x9999999
+				) {
 					char const* used_declare_format = nullptr;
 
-					if (
-						(
-							codegen::getStatus(*fn) == BindStatus::Unbindable && 
-							codegen::platformNumber(fn->binds) == -1 && 
-							fn->prototype.is_virtual && fn->prototype.type != FunctionType::Dtor
-						) || (
-							codegen::platformNumber(fn->binds) == 0x9999999
-						)
-					) {
-						used_declare_format = format_strings::declare_unimplemented_error;
-					}
-					else if (codegen::getStatus(*fn) != BindStatus::NeedsBinding && !codegen::shouldAndroidBind(fn)) {
+					if (codegen::getStatus(*fn) != BindStatus::NeedsBinding && !codegen::shouldAndroidBind(fn)) {
 						continue;
 					}
 

--- a/codegen/src/SourceGen.cpp
+++ b/codegen/src/SourceGen.cpp
@@ -234,11 +234,11 @@ std::string generateBindingSource(Root const& root, bool skipPugixml) {
 				} else if (codegen::getStatus(*fn) != BindStatus::Unbindable || codegen::platformNumber(fn->binds) != -1) {
 					char const* used_declare_format = nullptr;
 
-					if (codegen::getStatus(*fn) != BindStatus::NeedsBinding && !codegen::shouldAndroidBind(fn)) {
-						continue;
-					}
-					else if (codegen::platformNumber(fn->binds) == 0x9999999) {
+					if (codegen::platformNumber(fn->binds) == 0x9999999) {
 						used_declare_format = format_strings::declare_unimplemented_error;
+					}
+					else if (codegen::getStatus(*fn) != BindStatus::NeedsBinding && !codegen::shouldAndroidBind(fn)) {
+						continue;
 					}
 
 					if (!used_declare_format) {

--- a/codegen/src/SourceGen.cpp
+++ b/codegen/src/SourceGen.cpp
@@ -231,14 +231,14 @@ std::string generateBindingSource(Root const& root, bool skipPugixml) {
 							);
 							break;
 					}
-				} else if (
-					(codegen::getStatus(*fn) != BindStatus::Unbindable || codegen::platformNumber(fn->binds) != -1) &&
-					codegen::platformNumber(fn->binds) != 0x9999999
-				) {
+				} else if (codegen::getStatus(*fn) != BindStatus::Unbindable || codegen::platformNumber(fn->binds) != -1) {
 					char const* used_declare_format = nullptr;
 
 					if (codegen::getStatus(*fn) != BindStatus::NeedsBinding && !codegen::shouldAndroidBind(fn)) {
 						continue;
+					}
+					else if (codegen::platformNumber(fn->binds) == 0x9999999) {
+						used_declare_format = format_strings::declare_unimplemented_error;
 					}
 
 					if (!used_declare_format) {


### PR DESCRIPTION
This changes the behavior of Geometry Dash functions that are missing bindings to more closely match the behavior of cocos2d or FMOD functions that are missing bindings. That is, they will throw linker errors instead of compiler errors, so they will not cause too much annoyance.

However, you'll still get a compiler error when you modify a missing function. There is not much I can do about that.