### PR TITLE
Correct the path of SyncBromaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ We are mainly only looking for new addresses for the latest version of GD (Updat
 
 You can automatically sync addresses from-and-to Broma using the [`SyncBromaScript`](scripts/ghidra/SyncBromaScript.java) script for Ghidra. This script automatically pulls function names, signatures & addresses from Broma, adds them to your Ghidra project, and then adds any addresses you have found back into the Broma.
 
-**To install SyncBromaScript**, open up the `Script Manager` in Ghidra, then select `Manage Script Directories` from the top right toolbar. Add the path to the `scripts` directory in your local copy of Bindings, then refresh your scripts in `Script Manager`. You should see a `GeodeSDK` category appear with `SyncBromaScript.java` in it
+**To install SyncBromaScript**, open up the `Script Manager` in Ghidra, then select `Manage Script Directories` from the top right toolbar. Add the path to the `scripts/ghidra` directory in your local copy of Bindings, then refresh your scripts in `Script Manager`. You should see a `GeodeSDK` category appear with `SyncBromaScript.java` in it
 
 **Before running SyncBromaScript**, you should set up your Ghidra to be a good scripting environment by running the built-in `RecoverClassesFromRttiScript.java` from Ghidra. Note that `RecoverClassesFromRttiScript.java` can take over half an hour to finish.
 


### PR DESCRIPTION
Ghidra doesn't check subdirectories, so adding `scripts` adds only DumpVirtuals.java. The path to SyncBromaScript.java is `scripts/ghidra`.