### PR TITLE
too many bindings

### DIFF
--- a/bindings/2.2074/GeometryDash.bro
+++ b/bindings/2.2074/GeometryDash.bro
@@ -13484,7 +13484,7 @@ class GJShopLayer : cocos2d::CCLayer, GJPurchaseDelegate, DialogDelegate, Reward
     void onPlushies(cocos2d::CCObject* sender);
     void onSelectItem(cocos2d::CCObject* sender) = imac 0x310600, m1 0x2a6f30, ios 0x14f408;
     void onVideoAd(cocos2d::CCObject* sender) = imac 0x310400, m1 0x2a6d2c;
-    void showCantAffordMessage(GJStoreItem*) = m1 0x2a744c, imac 0x310b20, ios 0x14f74c;
+    void showCantAffordMessage(GJStoreItem*) = m1 0x2a744c, imac 0x310b20, ios 0x14f74c, win 0x2a4800;
     void showReactMessage() = win 0x2a58e0, m1 0x2a7f4c, imac 0x311740;
     void updateCurrencyCounter() = m1 0x2a73bc, imac 0x310a80, win 0x2a4580;
 


### PR DESCRIPTION
`GJShopLayer::showCantAffordMessage(GJStoreItem)`
`GJShopLayer::updateCurrencyCounter()`
`LeaderboardsLayer::onInfo(cocos2d::CCObject* sender)`
`LeaderboardsLayer::setupTabs()`
`LevelBrowserLayer::onRemoveAllFavorites()`
`ProfilePage::onInfo(cocos2d::CCObject* sender)`

and i can do a lot more but i have a life

also lots of free bindings around 0x28xxxx if anyone wants to get em