### PR TITLE
Fix unicode path handling in codegen

### DIFF
--- a/codegen/src/Main.cpp
+++ b/codegen/src/Main.cpp
@@ -133,7 +133,7 @@ int main(int argc, char** argv) try {
         if (auto sdkPath = std::getenv("GEODE_SDK")) {
             auto versionPath = std::filesystem::path(sdkPath) / "VERSION";
             if (std::filesystem::exists(versionPath)) {
-                std::ifstream versionFile(versionPath);
+                auto versionFile = openInputFile(versionPath);
                 std::string version;
                 std::getline(versionFile, version);
                 codegen::sdkVersion = codegen::Version::fromString(version);

--- a/codegen/src/Shared.hpp
+++ b/codegen/src/Shared.hpp
@@ -8,7 +8,41 @@
 #include <fstream>
 #include <filesystem>
 
+#ifdef _WIN32
+#include <windows.h>
+#include <io.h>
+#include <fcntl.h>
+#endif
+
 using std::istreambuf_iterator;
+
+// Cross-platform helper to open a file stream with Unicode path support
+// On Windows, we need to use wide strings for proper Unicode support
+#ifdef _WIN32
+inline std::ifstream openInputFile(std::filesystem::path const& path) {
+    std::ifstream file;
+    file.open(path.wstring());
+    return file;
+}
+
+inline std::ofstream openOutputFile(std::filesystem::path const& path) {
+    std::ofstream file;
+    file.open(path.wstring());
+    return file;
+}
+#else
+inline std::ifstream openInputFile(std::filesystem::path const& path) {
+    std::ifstream file;
+    file.open(path);
+    return file;
+}
+
+inline std::ofstream openOutputFile(std::filesystem::path const& path) {
+    std::ofstream file;
+    file.open(path);
+    return file;
+}
+#endif
 
 #ifdef _MSC_VER
     #pragma warning(disable : 4996)
@@ -32,15 +66,13 @@ std::string generateInlineSources(Root const& root, std::filesystem::path const&
 
 // returns true if the file contents were different (overwritten), false otherwise
 inline bool writeFile(std::filesystem::path const& writePath, std::string const& output) {
-    std::ifstream readfile;
+    auto readfile = openInputFile(writePath);
     readfile >> std::noskipws;
-    readfile.open(writePath);
     std::string data((std::istreambuf_iterator<char>(readfile)), std::istreambuf_iterator<char>());
     readfile.close();
 
     if (data != output) {
-        std::ofstream writefile;
-        writefile.open(writePath);
+        auto writefile = openOutputFile(writePath);
         writefile << output;
         writefile.close();
 


### PR DESCRIPTION
This PR fixes #126 - Unicode path handling in codegen.

## Problem
On Windows, `std::ifstream` and `std::ofstream` don't handle Unicode paths correctly when constructed from `std::filesystem::path`. They convert to narrow strings using the system code page, which causes failures when usernames or paths contain non-ASCII characters (e.g., ñ, é, 中).

## Solution
Added cross-platform helper functions `openInputFile()` and `openOutputFile()` in `Shared.hpp` that:
- On **Windows**: use `path.wstring()` to properly handle Unicode characters via the wide-character stream constructors
- On **other platforms**: use the standard `std::filesystem::path` constructor (no change needed)

## Changes
- `codegen/src/Shared.hpp`: Added helper functions and updated `writeFile()` to use them
- `codegen/src/Main.cpp`: Updated version file reading to use the new helper

## Testing
This fix allows codegen to work correctly when the bindings repository or SDK is located in paths containing Unicode characters, such as usernames with special characters.