### PR TITLE
Changed misnamed PlayerObject member variable (m_shipRotation -> m_lastPosition)

### DIFF
--- a/bindings/2.2081/GeometryDash.bro
+++ b/bindings/2.2081/GeometryDash.bro
@@ -14816,7 +14816,7 @@ class PlayerObject : GameObject, AnimatedSpriteDelegate {
     int m_groundObjectMaterial;
     float m_vehicleSize;
     float m_playerSpeed;
-    cocos2d::CCPoint m_shipRotation;
+    cocos2d::CCPoint m_lastPosition;
     cocos2d::CCPoint m_lastPortalPos;
     float m_unkUnused3;
     bool m_isOnGround2;


### PR DESCRIPTION
Verified by using a test mod that logs the variable every frame, value matches exactly the player's position last frame, not `m_shipRotation`. Also why would rotation be a CCPoint