### PR TITLE
Match CCFileUtils classes with headers

### DIFF
--- a/bindings/2.2081/Cocos2d.bro
+++ b/bindings/2.2081/Cocos2d.bro
@@ -1,4 +1,4 @@
-// #import win <Geode/cocos/platform/win32/CCFileUtilsWin32.h>
+#import win <Geode/cocos/platform/win32/CCFileUtilsWin32.h>
 #import android <Geode/cocos/platform/android/CCFileUtilsAndroid.h>
 #import mac <Geode/cocos/platform/mac/CCFileUtilsMac.h>
 #import ios <Geode/cocos/platform/ios/CCFileUtilsIOS.h>
@@ -1428,41 +1428,53 @@ class cocos2d::CCFadeTo : cocos2d::CCActionInterval {
 class cocos2d::CCFileUtils : cocos2d::TypeInfo {
     protected CCFileUtils() = m1 0x3ac624, imac 0x43ab10, ios 0x1509a4;
     // CCFileUtils(cocos2d::CCFileUtils const&);
+
+    static cocos2d::CCFileUtils* sharedFileUtils() = imac 0x60b8d0, m1 0x531b28, ios 0x23620c;
+    static void purgeFileUtils() = m1 0x3ac5f0, imac 0x43aae0, ios 0x150970;
+
     virtual ~CCFileUtils() = m1 0x3ac660, imac 0x43ab60, ios 0x1509e0;
 
-    static void purgeFileUtils() = m1 0x3ac5f0, imac 0x43aae0, ios 0x150970;
-    static cocos2d::CCFileUtils* sharedFileUtils() = imac 0x60b8d0, m1 0x531b28, ios 0x23620c;
-
-    virtual void addSearchPath(char const*) = imac 0x43d220, m1 0x3aec64, ios 0x151fc0;
-    virtual void addSearchResolutionsOrder(char const*) = imac 0x43cc80, m1 0x3ae744, ios 0x151c74;
-    virtual gd::string addSuffix(gd::string, gd::string) = imac 0x43b1a0, m1 0x3acce8, ios 0x150e5c;
-    virtual cocos2d::CCArray* createCCArrayWithContentsOfFile(gd::string const&) = imac 0x43aad0, m1 0x3ac5e8, ios 0x150968;
-    virtual cocos2d::CCDictionary* createCCDictionaryWithContentsOfFile(gd::string const&) = imac 0x43aab0, m1 0x3ac5d8, ios 0x150958;
-    virtual gd::string fullPathForFilename(char const*, bool) = imac 0x43b830, m1 0x3ad2c4, ios 0x1512b0;
-    virtual char const* fullPathFromRelativeFile(char const*, char const*) = imac 0x43c7e0, m1 0x3ae298, ios 0x151988;
-    virtual unsigned char* getFileData(char const*, char const*, unsigned long*) = imac 0x43ad80, m1 0x3ac8c0, ios 0x150b24;
-    virtual unsigned char* getFileDataFromZip(char const*, char const*, unsigned long*) = imac 0x43aec0, m1 0x3aca2c, ios 0x150c74;
-    virtual gd::string getFullPathForDirectoryAndFilename(gd::string const&, gd::string const&) = imac 0x43db00, m1 0x3af5bc, ios 0x152458;
-    virtual gd::string getNewFilename(char const*) = imac 0x43aff0, m1 0x3acb4c, ios 0x150d90;
-    virtual gd::string getPathForFilename(gd::string const&, gd::string const&, gd::string const&) = imac 0x43b3e0, m1 0x3aceec, ios 0x151060;
-    virtual gd::vector<gd::string> const& getSearchPaths() = imac 0x43cd70, m1 0x3ae844, ios 0x151ce0;
-    virtual gd::vector<gd::string> const& getSearchResolutionsOrder() = imac 0x43cd60, m1 0x3ae83c, ios 0x151cd8;
-    virtual gd::string getWritablePath2() = imac 0x43dd30, m1 0x3af7ec, ios 0x152584;
-    virtual bool init() = imac 0x43ac80, m1 0x3ac7b0, ios 0x150a78;
-    virtual bool isAbsolutePath(gd::string const&) = imac 0x43dc70, m1 0x3af724, ios 0x1524c8;
-    virtual bool isPopupNotify() = imac 0x43dca0, m1 0x3af750, ios 0x1524f4;
-    virtual void loadFilenameLookupDictionaryFromFile(char const*) = imac 0x43d990, m1 0x3af3d8, ios 0x1522e8;
     virtual void purgeCachedEntries() = imac 0x43ad50, m1 0x3ac890, ios 0x150af4;
-    virtual void removeFullPath(char const*) = imac 0x43c680, m1 0x3ae028, ios 0x1518f8;
-    virtual void removeSearchPath(char const*) = imac 0x43d530, m1 0x3aef7c, ios 0x1520f8;
-    virtual void setFilenameLookupDictionary(cocos2d::CCDictionary*) = imac 0x43d920, m1 0x3af370, ios 0x152280;
-    virtual void setPopupNotify(bool) = imac 0x43dc90, m1 0x3af744, ios 0x1524e8;
-    virtual void setSearchPaths(gd::vector<gd::string> const&) = imac 0x43cd80, m1 0x3ae84c, ios 0x151ce8;
-    virtual void setSearchResolutionsOrder(gd::vector<gd::string> const&) = imac 0x43ca40, m1 0x3ae504, ios 0x151aec;
-    virtual bool shouldUseHD() = imac 0x43b170, m1 0x3accc4, ios 0x150e38;
-    virtual bool writeToFile(cocos2d::CCDictionary*, gd::string const&) = imac 0x43aac0, m1 0x3ac5e0, ios 0x150960;
+    virtual unsigned char* getFileData(char const* pszFileName, char const* pszMode, unsigned long* pSize) = imac 0x43ad80, m1 0x3ac8c0, ios 0x150b24;
+    virtual unsigned char* getFileDataFromZip(char const* pszZipFilePath, char const* pszFileName, unsigned long* pSize) = imac 0x43aec0, m1 0x3aca2c, ios 0x150c74;
+    virtual gd::string fullPathForFilename(char const* pszFileName, bool skipSuffix) = imac 0x43b830, m1 0x3ad2c4, ios 0x1512b0;
+    virtual void removeFullPath(char const* path) = imac 0x43c680, m1 0x3ae028, ios 0x1518f8;
+    virtual void loadFilenameLookupDictionaryFromFile(char const* filename) = imac 0x43d990, m1 0x3af3d8, ios 0x1522e8;
+    virtual void setFilenameLookupDictionary(cocos2d::CCDictionary* pFilenameLookupDict) = imac 0x43d920, m1 0x3af370, ios 0x152280;
+    virtual char const* fullPathFromRelativeFile(char const* pszFilename, char const* pszRelativeFile) = imac 0x43c7e0, m1 0x3ae298, ios 0x151988;
+    virtual void setSearchResolutionsOrder(gd::vector<gd::string> const& searchResolutionsOrder) = imac 0x43ca40, m1 0x3ae504, ios 0x151aec;
+    virtual void addSearchResolutionsOrder(char const* order) = imac 0x43cc80, m1 0x3ae744, ios 0x151c74;
+    virtual gd::vector<gd::string> const& getSearchResolutionsOrder() = imac 0x43cd60, m1 0x3ae83c, ios 0x151cd8;
+    virtual void setSearchPaths(gd::vector<gd::string> const& searchPaths) = imac 0x43cd80, m1 0x3ae84c, ios 0x151ce8;
+    virtual void addSearchPath(char const* path) = imac 0x43d220, m1 0x3aec64, ios 0x151fc0;
+    virtual void removeSearchPath(char const* path) = imac 0x43d530, m1 0x3aef7c, ios 0x1520f8;
 
     void removeAllPaths() = m1 0x3af324, imac 0x43d8d0, ios inline;
+
+    virtual gd::vector<gd::string> const& getSearchPaths() = imac 0x43cd70, m1 0x3ae844, ios 0x151ce0;
+    virtual gd::string getWritablePath() = inline;
+    virtual gd::string getWritablePath2() = imac 0x43dd30, m1 0x3af7ec, ios 0x152584;
+    virtual gd::string isFileExist(gd::string const& strFilePath) = inline;
+    virtual bool isAbsolutePath(gd::string const& strPath) = imac 0x43dc70, m1 0x3af724, ios 0x1524c8;
+    virtual void setPopupNotify(bool bNotify) = imac 0x43dc90, m1 0x3af744, ios 0x1524e8;
+    virtual bool isPopupNotify() = imac 0x43dca0, m1 0x3af750, ios 0x1524f4;
+    virtual bool init() = imac 0x43ac80, m1 0x3ac7b0, ios 0x150a78;
+    virtual gd::string getNewFilename(char const* pszFileName) = imac 0x43aff0, m1 0x3acb4c, ios 0x150d90;
+    virtual bool shouldUseHD() = imac 0x43b170, m1 0x3accc4, ios 0x150e38;
+    virtual gd::string addSuffix(gd::string, gd::string) = imac 0x43b1a0, m1 0x3acce8, ios 0x150e5c;
+    virtual gd::string getPathForFilename(gd::string const& filename, gd::string const& resolutionDirectory, gd::string const& searchPath) = imac 0x43b3e0, m1 0x3aceec, ios 0x151060;
+    virtual gd::string getFullPathForDirectoryAndFilename(gd::string const& strDirectory, gd::string const& strFilename) = imac 0x43db00, m1 0x3af5bc, ios 0x152458;
+    virtual cocos2d::CCDictionary* createCCDictionaryWithContentsOfFile(gd::string const& filename) = imac 0x43aab0, m1 0x3ac5d8, ios 0x150958;
+    virtual bool writeToFile(cocos2d::CCDictionary* dict, gd::string const& fullPath) = imac 0x43aac0, m1 0x3ac5e0, ios 0x150960;
+    virtual cocos2d::CCArray* createCCArrayWithContentsOfFile(gd::string const& filename) = imac 0x43aad0, m1 0x3ac5e8, ios 0x150968;
+
+    CCDictionary* m_pFilenameLookupDict;
+    gd::vector<gd::string> m_searchResolutionsOrderArray;
+    gd::vector<gd::string> m_searchPathArray;
+    gd::string m_strDefaultResRootPath;
+    gd::map<gd::string, gd::string> m_fullPathCache;
+    gd::string m_strAndroidPath;
+    CCFileUtils* s_sharedFileUtils;
 }
 
 [[link(android), missing(win, mac, ios)]]
@@ -1470,53 +1482,53 @@ class cocos2d::CCFileUtilsAndroid : cocos2d::CCFileUtils {
     private CCFileUtilsAndroid();
     virtual ~CCFileUtilsAndroid();
 
-    virtual unsigned char* getFileData(char const*, char const*, unsigned long*);
-    virtual gd::string getWritablePath();
     virtual bool init();
-    virtual bool isAbsolutePath(gd::string const&);
-    virtual bool isFileExist(gd::string const&);
+    virtual unsigned char* getFileData(char const* pszFileName, char const* pszMode, unsigned long* pSize);
+    virtual gd::string getWritablePath();
+    virtual bool isFileExist(gd::string const& strFilePath);
+    virtual bool isAbsolutePath(gd::string const& strPath);
 
-    unsigned char* doGetFileData(char const*, char const*, unsigned long*, bool);
-    unsigned char* getFileDataForAsync(char const*, char const*, unsigned long*);
+    unsigned char* getFileDataForAsync(char const* pszFileName, char const* pszMode, unsigned long* pSize);
+    unsigned char* doGetFileData(char const* pszFileName, char const* pszMode, unsigned long* pSize, bool forAsync);
 }
 
 [[missing(win, android, mac)]]
 class cocos2d::CCFileUtilsIOS : cocos2d::CCFileUtils {
-    virtual cocos2d::CCArray* createCCArrayWithContentsOfFile(gd::string const&) = ios 0x236ee8;
-    virtual cocos2d::CCDictionary* createCCDictionaryWithContentsOfFile(gd::string const&) = ios 0x236694;
-    virtual gd::string getFullPathForDirectoryAndFilename(gd::string const&, gd::string const&) = ios 0x23651c;
     virtual gd::string getWritablePath() = ios 0x23628c;
-    virtual bool isAbsolutePath(gd::string const&) = ios 0x236668;
-    virtual bool isFileExist(gd::string const&) = ios 0x2362f8;
-    virtual bool writeToFile(cocos2d::CCDictionary*, gd::string const&) = ios 0x236cf0;
+    virtual bool isFileExist(gd::string const& strFilePath) = ios 0x2362f8;
+    virtual bool isAbsolutePath(gd::string const& strPath) = ios 0x236668;
+    virtual gd::string getFullPathForDirectoryAndFilename(gd::string const& strDirectory, gd::string const& strFilename) = ios 0x23651c;
+    virtual cocos2d::CCDictionary* createCCDictionaryWithContentsOfFile(gd::string const& filename) = ios 0x236694;
+    virtual bool writeToFile(cocos2d::CCDictionary* dict, gd::string const& fullPath) = ios 0x236cf0;
+    virtual cocos2d::CCArray* createCCArrayWithContentsOfFile(gd::string const& filename) = ios 0x236ee8;
 }
 
 [[missing(win, android, ios)]]
 class cocos2d::CCFileUtilsMac : cocos2d::CCFileUtils {
-    virtual cocos2d::CCArray* createCCArrayWithContentsOfFile(gd::string const&) = m1 0x532d7c, imac 0x60ceb0;
-    virtual cocos2d::CCDictionary* createCCDictionaryWithContentsOfFile(gd::string const&) = m1 0x53229c, imac 0x60c100;
-    virtual gd::string getFullPathForDirectoryAndFilename(gd::string const&, gd::string const&) = m1 0x532014, imac 0x60bdd0;
     virtual gd::string getWritablePath() = m1 0x531bb4, imac 0x60b960;
-    virtual bool isAbsolutePath(gd::string const&) = m1 0x532270, imac 0x60c0b0;
-    virtual bool isFileExist(gd::string const&) = m1 0x531c98, imac 0x60ba60;
-    virtual bool writeToFile(cocos2d::CCDictionary*, gd::string const&) = m1 0x532b8c, imac 0x60cc60;
+    virtual bool isFileExist(gd::string const& strFilePath) = m1 0x531c98, imac 0x60ba60;
+    virtual bool isAbsolutePath(gd::string const& strPath) = m1 0x532270, imac 0x60c0b0;
+    virtual gd::string getFullPathForDirectoryAndFilename(gd::string const& strDirectory, gd::string const& strFilename) = m1 0x532014, imac 0x60bdd0;
+    virtual cocos2d::CCDictionary* createCCDictionaryWithContentsOfFile(gd::string const& filename) = m1 0x53229c, imac 0x60c100;
+    virtual bool writeToFile(cocos2d::CCDictionary* dict, gd::string const& fullPath) = m1 0x532b8c, imac 0x60cc60;
+    virtual cocos2d::CCArray* createCCArrayWithContentsOfFile(gd::string const& filename) = m1 0x532d7c, imac 0x60ceb0;
 }
 
 [[link(win), missing(android, mac, ios)]]
 class cocos2d::CCFileUtilsWin32 : cocos2d::CCFileUtils {
     // private CCFileUtilsWin32();
 
-    virtual void addSearchPath(char const*);
-    virtual gd::string fullPathForFilename(char const*);
-    virtual gd::string getPathForFilename(gd::string const&, gd::string const&, gd::string const&);
+    virtual bool init();
+    virtual void addSearchPath(char const* path);
+    virtual void removeSearchPath(char const* path);
     virtual gd::string getWritablePath();
     virtual gd::string getWritablePath2();
-    virtual bool init();
-    virtual bool isAbsolutePath(gd::string const&);
-    virtual bool isFileExist(gd::string const&);
-    virtual void removeSearchPath(char const*);
+    virtual bool isFileExist(gd::string const& strFilePath);
+    virtual bool isAbsolutePath(gd::string const& strPath);
+    virtual gd::string getPathForFilename(gd::string const& filename, gd::string const& resolutionDirectory, gd::string const& searchPath);
+    virtual gd::string fullPathForFilename(char const* pszFileName);
 
-    gd::string utf8Togbk(char const*);
+    gd::string utf8Togbk(char const* src);
 }
 
 [[link(win, android)]]

--- a/bindings/2.2081/Cocos2d.bro
+++ b/bindings/2.2081/Cocos2d.bro
@@ -1468,13 +1468,13 @@ class cocos2d::CCFileUtils : cocos2d::TypeInfo {
     virtual bool writeToFile(cocos2d::CCDictionary* dict, gd::string const& fullPath) = imac 0x43aac0, m1 0x3ac5e0, ios 0x150960;
     virtual cocos2d::CCArray* createCCArrayWithContentsOfFile(gd::string const& filename) = imac 0x43aad0, m1 0x3ac5e8, ios 0x150968;
 
-    CCDictionary* m_pFilenameLookupDict;
+    cocos2d::CCDictionary* m_pFilenameLookupDict;
     gd::vector<gd::string> m_searchResolutionsOrderArray;
     gd::vector<gd::string> m_searchPathArray;
     gd::string m_strDefaultResRootPath;
     gd::map<gd::string, gd::string> m_fullPathCache;
     gd::string m_strAndroidPath;
-    CCFileUtils* s_sharedFileUtils;
+    cocos2d::CCFileUtils* s_sharedFileUtils;
 }
 
 [[link(android), missing(win, mac, ios)]]

--- a/bindings/2.2081/Cocos2d.bro
+++ b/bindings/2.2081/Cocos2d.bro
@@ -1454,7 +1454,7 @@ class cocos2d::CCFileUtils : cocos2d::TypeInfo {
     virtual gd::vector<gd::string> const& getSearchPaths() = imac 0x43cd70, m1 0x3ae844, ios 0x151ce0;
     virtual gd::string getWritablePath() = inline;
     virtual gd::string getWritablePath2() = imac 0x43dd30, m1 0x3af7ec, ios 0x152584;
-    virtual gd::string isFileExist(gd::string const& strFilePath) = inline;
+    virtual bool isFileExist(gd::string const& strFilePath) = inline;
     virtual bool isAbsolutePath(gd::string const& strPath) = imac 0x43dc70, m1 0x3af724, ios 0x1524c8;
     virtual void setPopupNotify(bool bNotify) = imac 0x43dc90, m1 0x3af744, ios 0x1524e8;
     virtual bool isPopupNotify() = imac 0x43dca0, m1 0x3af750, ios 0x1524f4;

--- a/bindings/2.2081/Cocos2d.bro
+++ b/bindings/2.2081/Cocos2d.bro
@@ -1426,13 +1426,13 @@ class cocos2d::CCFadeTo : cocos2d::CCActionInterval {
 
 [[link(win, android)]]
 class cocos2d::CCFileUtils : cocos2d::TypeInfo {
-    protected CCFileUtils() = m1 0x3ac624, imac 0x43ab10, ios 0x1509a4;
+    protected CCFileUtils() = imac 0x43ab10, m1 0x3ac624, ios 0x1509a4;
     // CCFileUtils(cocos2d::CCFileUtils const&);
 
     static cocos2d::CCFileUtils* sharedFileUtils() = imac 0x60b8d0, m1 0x531b28, ios 0x23620c;
-    static void purgeFileUtils() = m1 0x3ac5f0, imac 0x43aae0, ios 0x150970;
+    static void purgeFileUtils() = imac 0x43aae0, m1 0x3ac5f0, ios 0x150970;
 
-    virtual ~CCFileUtils() = m1 0x3ac660, imac 0x43ab60, ios 0x1509e0;
+    virtual ~CCFileUtils() = imac 0x43ab60, m1 0x3ac660, ios 0x1509e0;
 
     virtual void purgeCachedEntries() = imac 0x43ad50, m1 0x3ac890, ios 0x150af4;
     virtual unsigned char* getFileData(char const* pszFileName, char const* pszMode, unsigned long* pSize) = imac 0x43ad80, m1 0x3ac8c0, ios 0x150b24;
@@ -1449,7 +1449,7 @@ class cocos2d::CCFileUtils : cocos2d::TypeInfo {
     virtual void addSearchPath(char const* path) = imac 0x43d220, m1 0x3aec64, ios 0x151fc0;
     virtual void removeSearchPath(char const* path) = imac 0x43d530, m1 0x3aef7c, ios 0x1520f8;
 
-    void removeAllPaths() = m1 0x3af324, imac 0x43d8d0, ios inline;
+    void removeAllPaths() = imac 0x43d8d0, m1 0x3af324, ios inline;
 
     virtual gd::vector<gd::string> const& getSearchPaths() = imac 0x43cd70, m1 0x3ae844, ios 0x151ce0;
     virtual gd::string getWritablePath() = inline;
@@ -1505,13 +1505,13 @@ class cocos2d::CCFileUtilsIOS : cocos2d::CCFileUtils {
 
 [[missing(win, android, ios)]]
 class cocos2d::CCFileUtilsMac : cocos2d::CCFileUtils {
-    virtual gd::string getWritablePath() = m1 0x531bb4, imac 0x60b960;
-    virtual bool isFileExist(gd::string const& strFilePath) = m1 0x531c98, imac 0x60ba60;
-    virtual bool isAbsolutePath(gd::string const& strPath) = m1 0x532270, imac 0x60c0b0;
-    virtual gd::string getFullPathForDirectoryAndFilename(gd::string const& strDirectory, gd::string const& strFilename) = m1 0x532014, imac 0x60bdd0;
-    virtual cocos2d::CCDictionary* createCCDictionaryWithContentsOfFile(gd::string const& filename) = m1 0x53229c, imac 0x60c100;
-    virtual bool writeToFile(cocos2d::CCDictionary* dict, gd::string const& fullPath) = m1 0x532b8c, imac 0x60cc60;
-    virtual cocos2d::CCArray* createCCArrayWithContentsOfFile(gd::string const& filename) = m1 0x532d7c, imac 0x60ceb0;
+    virtual gd::string getWritablePath() = imac 0x60b960, m1 0x531bb4;
+    virtual bool isFileExist(gd::string const& strFilePath) = imac 0x60ba60, m1 0x531c98;
+    virtual bool isAbsolutePath(gd::string const& strPath) = imac 0x60c0b0, m1 0x532270;
+    virtual gd::string getFullPathForDirectoryAndFilename(gd::string const& strDirectory, gd::string const& strFilename) = imac 0x60bdd0, m1 0x532014;
+    virtual cocos2d::CCDictionary* createCCDictionaryWithContentsOfFile(gd::string const& filename) = imac 0x60c100, m1 0x53229c;
+    virtual bool writeToFile(cocos2d::CCDictionary* dict, gd::string const& fullPath) = imac 0x60cc60, m1 0x532b8c;
+    virtual cocos2d::CCArray* createCCArrayWithContentsOfFile(gd::string const& filename) = imac 0x60ceb0, m1 0x532d7c;
 }
 
 [[link(win), missing(android, mac, ios)]]

--- a/bindings/2.2081/inline/CCFileUtils.cpp
+++ b/bindings/2.2081/inline/CCFileUtils.cpp
@@ -1,6 +1,10 @@
 #include <Geode/Bindings.hpp>
 
 
+virtual gd::string cocos2d::CCFileUtils::getWritablePath() { return ""; }
+
+virtual bool cocos2d::CCFileUtils::isFileExist(const gd::string& strFilePath) { return false; }
+
 #if defined(GEODE_IS_WINDOWS) || defined(GEODE_IS_IOS)
 #endif
 

--- a/bindings/2.2081/inline/CCFileUtils.cpp
+++ b/bindings/2.2081/inline/CCFileUtils.cpp
@@ -1,10 +1,6 @@
 #include <Geode/Bindings.hpp>
 
 
-virtual gd::string cocos2d::CCFileUtils::getWritablePath() { return ""; }
-
-virtual bool cocos2d::CCFileUtils::isFileExist(const gd::string& strFilePath) { return false; }
-
 #if defined(GEODE_IS_WINDOWS) || defined(GEODE_IS_IOS)
 #endif
 


### PR DESCRIPTION
Added two inlined stubs to CCFileUtils, which are overriden by platform-specific classes.
Redid the order of functions, and added the members, all matching with the Cocos2d-x headers in Geode SDK.
Uncommented the CCFileUtilsWin32 header import as per green light from Jasmine.