### PR TITLE
Update Broma and other used packages to latest versions

### DIFF
--- a/codegen/CMakeLists.txt
+++ b/codegen/CMakeLists.txt
@@ -3,11 +3,9 @@ project(Codegen LANGUAGES C CXX)
 
 include(../cmake/CPM.cmake)
 
-CPMAddPackage("gh:fmtlib/fmt#11.0.2")
-CPMAddPackage("gh:geode-sdk/Broma#19fa02c")
-CPMAddPackage("gh:geode-sdk/json@3.2.1")
-
-target_compile_definitions(fmt PUBLIC -DFMT_CONSTEVAL=)
+CPMAddPackage("gh:fmtlib/fmt#12.2.0")
+CPMAddPackage("gh:geode-sdk/Broma#4565343")
+CPMAddPackage("gh:geode-sdk/json@3.3.0")
 
 file(GLOB SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp
@@ -25,10 +23,10 @@ add_executable(${PROJECT_NAME}
 	src/PredeclareGen.cpp
 	src/SourceGen.cpp
 )
-target_compile_features(Codegen PUBLIC cxx_std_17)
+target_compile_features(Codegen PUBLIC cxx_std_20)
 
 target_link_libraries(Codegen PRIVATE fmt::fmt Broma mat-json)
-target_include_directories(Codegen PRIVATE 
+target_include_directories(Codegen PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 

--- a/codegen/CMakeLists.txt
+++ b/codegen/CMakeLists.txt
@@ -7,6 +7,8 @@ CPMAddPackage("gh:fmtlib/fmt#12.2.0")
 CPMAddPackage("gh:geode-sdk/Broma#4565343")
 CPMAddPackage("gh:geode-sdk/json@3.3.0")
 
+target_compile_definitions(fmt PUBLIC -DFMT_CONSTEVAL=)
+
 file(GLOB SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp
 )

--- a/codegen/src/Main.cpp
+++ b/codegen/src/Main.cpp
@@ -1,6 +1,7 @@
 #include "Shared.hpp"
 
 #include <filesystem>
+#include <iostream>
 
 using namespace codegen;
 
@@ -47,6 +48,7 @@ int main(int argc, char** argv) try {
 
     std::string p = argv[1];
 
+    // NOTE: add geode::Result stuff for broma::parse_file if you restore this
     // if (p == "--into-json") {
     //     auto rootDir = std::filesystem::path(argv[2]);
     //     std::filesystem::current_path(rootDir);
@@ -115,7 +117,14 @@ int main(int argc, char** argv) try {
     // std::filesystem::create_directories(writeDir / "inline");
 
     auto rootDir = std::filesystem::path(argv[2]);
-    Root root = broma::parse_file(rootDir / "Entry.bro");
+    auto parsed = broma::parse_file(rootDir / "Entry.bro");
+    if (parsed.isErr()) {
+        std::string msg;
+        for (auto& e : parsed.unwrapErr().messages)
+            msg += e + "\n";
+        throw codegen::error("Failed to parse bindings file: {}", msg);
+    }
+    Root root = parsed.unwrap();
     bool skipInlines = std::filesystem::exists(rootDir / "inline");
 
     for (auto cls : root.classes) {

--- a/codegen/src/Shared.hpp
+++ b/codegen/src/Shared.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <array>
-#include <unordered_set>
 #include <broma.hpp>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
+#include <array>
+#include <unordered_set>
+#include <map>
 #include <fstream>
 #include <filesystem>
 
@@ -99,7 +100,7 @@ namespace codegen {
         for (auto& f : root.functions) {
             idMap[&f] = id++;
         }
-        
+
         for (auto& c : root.classes) {
             for (auto& f : c.fields) {
                 if (auto fn = f.get_as<FunctionBindField>()) {
@@ -219,7 +220,7 @@ namespace codegen {
             codegen::sdkVersion < fn.prototype.attributes.since ||
             (fn.prototype.attributes.missing & p) != Platform::None
         ) return BindStatus::Missing;
-        
+
         if (platformNumberWithPlatform(p, fn.binds) == -2) return BindStatus::Inlined;
 
         if ((fn.prototype.attributes.links & p) != Platform::None) {
@@ -230,7 +231,7 @@ namespace codegen {
                     if (can_find(type.name, "gd::")) return BindStatus::NeedsRebinding;
                 }
             }
-            
+
             return BindStatus::Binded;
         }
 


### PR DESCRIPTION
Updates geode-sdk/Broma to the latest upstream and applies necessary changes for staying functional.
Broma now uses the geode-sdk/result package for file parsing.

Compiles and runs fine for me locally.