### PR TITLE
rename m_somethingPlayerSpeedTime to m_lastMovedTime

### DIFF
--- a/bindings/2.2081/GeometryDash.bro
+++ b/bindings/2.2081/GeometryDash.bro
@@ -14939,6 +14939,7 @@ class PlayerObject : GameObject, AnimatedSpriteDelegate {
     cocos2d::CCPoint m_stateForceVector;
     bool m_affectedByForces;
     gd::map<int, bool> m_jumpPadRelated;
+    [[renamed_from(m_somethingPlayerSpeedTime)]]
     float m_lastMovedTime;
     float m_playerSpeedAC;
     bool m_fixRobotJump;

--- a/bindings/2.2081/GeometryDash.bro
+++ b/bindings/2.2081/GeometryDash.bro
@@ -14939,7 +14939,7 @@ class PlayerObject : GameObject, AnimatedSpriteDelegate {
     cocos2d::CCPoint m_stateForceVector;
     bool m_affectedByForces;
     gd::map<int, bool> m_jumpPadRelated;
-    float m_somethingPlayerSpeedTime;
+    float m_lastMovedTime;
     float m_playerSpeedAC;
     bool m_fixRobotJump;
     gd::map<int, bool> m_holdingButtons;


### PR DESCRIPTION
the member is a timestamp that is used in `PlayerObject::updateMove` to decide when to trigger the idle animations when still standing on the ground for different gamemodes